### PR TITLE
create spec file

### DIFF
--- a/python/protocaas/cli.py
+++ b/python/protocaas/cli.py
@@ -1,20 +1,46 @@
 import click
 from .compute_resource.register_compute_resource import register_compute_resource as register_compute_resource_function
 from .compute_resource.start_compute_resource import start_compute_resource as start_compute_resource_function
+from .sdk._make_spec_file import make_app_spec_file_function
 
-@click.group(help="protocaas command line interface")
-def main():
-    pass
-
+# ------------------------------------------------------------
+# Compute resource cli
+# ------------------------------------------------------------
 @click.command(help='Initialize a compute resource node in the current directory')
 @click.option('--compute-resource-id', default=None, help='Compute resource ID')
 @click.option('--compute-resource-private-key', default=None, help='Compute resource private key')
 def register_compute_resource(compute_resource_id: str, compute_resource_private_key: str):
     register_compute_resource_function(dir='.', compute_resource_id=compute_resource_id, compute_resource_private_key=compute_resource_private_key)
 
+
 @click.command(help="Start the compute resource node in the current directory")
 def start_compute_resource():
     start_compute_resource_function(dir='.')
 
+
+# ------------------------------------------------------------
+# App cli
+# ------------------------------------------------------------
+@click.command(help='Make an app spec file')
+@click.option('--app-dir', default='.', help='Path to the app directory')
+@click.option('--spec-output-file', default=None, help='Output file for the spec')
+def make_app_spec_file(app_dir: str, spec_output_file: str):
+    make_app_spec_file_function(app_dir=app_dir, spec_output_file=spec_output_file)
+
+
+# TODO: Implement this
+@click.command(help='Run an app')
+def run_app():
+    pass
+
+# ------------------------------------------------------------
+# Main cli
+# ------------------------------------------------------------
+@click.group(help="protocaas command line interface")
+def main():
+    pass
+
 main.add_command(register_compute_resource)
 main.add_command(start_compute_resource)
+main.add_command(make_app_spec_file)
+main.add_command(run_app)

--- a/python/protocaas/sdk/_make_spec_file.py
+++ b/python/protocaas/sdk/_make_spec_file.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import importlib.util
+import os 
 
 import protocaas.sdk as pr
 
@@ -22,6 +23,7 @@ def make_app_spec_file_function(app_dir: str, spec_output_file: str = None):
     module_name = app_dir_path.name
 
     # Use importlib to load the module
+    os.environ['PROTOCAAS_GENERATE_SPEC'] = '1'
     spec = importlib.util.spec_from_file_location(module_name, str(main_module_path))
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/python/protocaas/sdk/_make_spec_file.py
+++ b/python/protocaas/sdk/_make_spec_file.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import importlib.util
+
+import protocaas.sdk as pr
+
+
+def make_app_spec_file_function(app_dir: str, spec_output_file: str = None):
+    # Ensure the directory path is an absolute path
+    app_dir_path = Path(app_dir).resolve()
+
+    if spec_output_file is None:
+        spec_output_file = str(app_dir_path / 'spec.json')
+
+    # Construct the absolute path to main.py in the specified directory
+    main_module_path = app_dir_path / 'main.py'
+
+    # Check if main.py exists
+    if not main_module_path.exists():
+        raise FileNotFoundError(f"main.py not found in {app_dir_path}")
+
+    # Create a module name from the directory path
+    module_name = app_dir_path.name
+
+    # Use importlib to load the module
+    spec = importlib.util.spec_from_file_location(module_name, str(main_module_path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # Check if the App class exists in the loaded module
+    if hasattr(module, 'app') and isinstance(getattr(module, 'app'), pr.App):
+        # Create an instance of the App class
+        app_instance = module.app
+
+        # Call the make_spec_file method
+        app_instance.make_spec_file(spec_output_file)
+    else:
+        raise AttributeError("App class not found in main.py")

--- a/python/protocaas/sdk/decorators.py
+++ b/python/protocaas/sdk/decorators.py
@@ -3,7 +3,7 @@ from .AppProcessor import _NO_DEFAULT
 
 
 # This decorator is used to define a processor
-def processor(name, help=None):
+def processor(name, help: str=None):
     def decorator(func):
         setattr(func, 'protocaas_processor', {'name': name, 'help': help})
         return func


### PR DESCRIPTION
- [x] Separate the logic of creating spec file from run
- [x] add this as a cli functionality, this can be useful for developers and for automatic actions 
- [x] remove the necessity of `generate_spec.sh` files in the apps directories 

example usage, from the root dir of an apps repository:
```bash
protocaas make-app-spec-file --app-dir ./kilosort2_5/
```

the `main.py` file of the app:
```python
import os
import protocaas.sdk as pr

try:
    import h5py
    import remfile
    import pynwb
    ...
except ImportError:
    # Do not raise import error if we are only generating the spec
    if os.environ.get('PROTOCAAS_GENERATE_SPEC', None) != '1':
        raise


app = pr.App(
    'kilosort2_5', 
    help="Kilosort 2.5 spike sorting",
    app_image="magland/pc-kilosort2_5",
    app_executable="/app/main"
)
...
```