### PR TITLE
support optional types for parameters

### DIFF
--- a/python/dendro/api_helpers/services/gui/create_job.py
+++ b/python/dendro/api_helpers/services/gui/create_job.py
@@ -35,6 +35,14 @@ async def create_job(
     user_id: str,
     dandi_api_key: Union[str, None] = None
 ):
+    _check_job_is_consistent_with_processor_spec(
+        processor_spec=processor_spec,
+        processor_name=processor_name,
+        input_files_from_request=input_files_from_request,
+        output_files_from_request=output_files_from_request,
+        input_parameters=input_parameters
+    )
+
     project = await fetch_project(project_id)
     assert project is not None, f"No project with ID {project_id}"
 
@@ -145,3 +153,84 @@ async def create_job(
     )
 
     return job_id
+
+def _check_job_is_consistent_with_processor_spec(
+    processor_spec: ComputeResourceSpecProcessor,
+    processor_name: str,
+    input_files_from_request: List[CreateJobRequestInputFile],
+    output_files_from_request: List[CreateJobRequestOutputFile],
+    input_parameters: List[CreateJobRequestInputParameter]
+):
+    # check that the processor name matches
+    if processor_spec.name != processor_name:
+        raise CreateJobException(f"Processor name mismatch: {processor_spec.name} != {processor_name}")
+
+    # check that the input files are consistent with the spec
+    for input_file in input_files_from_request:
+        if input_file.name.endswith(']'):
+            base_name = input_file.name.split('[')[0]
+            xx = next((x for x in processor_spec.inputs if x.name == base_name), None)
+            if not xx:
+                raise CreateJobException(f"Processor input not found: {base_name}")
+            if not xx.list:
+                raise CreateJobException(f"Processor input is not a list: {base_name}")
+        else:
+            xx = next((x for x in processor_spec.inputs if x.name == input_file.name), None)
+            if not xx:
+                raise CreateJobException(f"Processor input not found: {input_file.name}")
+
+    # check that all the required inputs are present
+    for input in processor_spec.inputs:
+        if not input.list:
+            if not any(x.name == input.name for x in input_files_from_request):
+                raise CreateJobException(f"Required input not found: {input.name}")
+
+    # check that the output files are consistent with the spec
+    for output_file in output_files_from_request:
+        xx = next((x for x in processor_spec.outputs if x.name == output_file.name), None)
+        if not xx:
+            raise CreateJobException(f"Processor output not found: {output_file.name}")
+
+    # check that the required output files are present
+    for output in processor_spec.outputs:
+        if not any(x.name == output.name for x in output_files_from_request):
+            raise CreateJobException(f"Required output not found: {output.name}")
+
+    # check that the input parameters are consistent with the spec
+    for input_parameter in input_parameters:
+        pp = next((x for x in processor_spec.parameters if x.name == input_parameter.name), None)
+        if not pp:
+            raise CreateJobException(f"Processor parameter not found: {input_parameter.name}")
+        if not _parameter_value_is_consistent_with_type(input_parameter.value, pp.type):
+            raise CreateJobException(f"Parameter value is not consistent with type: {input_parameter.name} {input_parameter.value} {pp.type}")
+
+    # check that the parameters that do not have a default are present
+    for pp in processor_spec.parameters:
+        if pp.default is None and not pp.type.startswith('Optional['):
+            input_parameter = next((x for x in input_parameters if x.name == pp.name), None)
+            if not input_parameter:
+                raise CreateJobException(f"Required parameter not found: {pp.name}")
+
+def _parameter_value_is_consistent_with_type(value: Any, type: str):
+    if type == 'str':
+        return isinstance(value, str)
+    elif type == 'int':
+        return isinstance(value, int)
+    elif type == 'float':
+        return isinstance(value, float) or isinstance(value, int)
+    elif type == 'bool':
+        return isinstance(value, bool)
+    elif type == 'List[str]':
+        return isinstance(value, list) and all(isinstance(x, str) for x in value)
+    elif type == 'List[int]':
+        return isinstance(value, list) and all(isinstance(x, int) for x in value)
+    elif type == 'List[float]':
+        return isinstance(value, list) and all(isinstance(x, float) or isinstance(x, int) for x in value)
+    elif type == 'List[bool]':
+        return isinstance(value, list) and all(isinstance(x, bool) for x in value)
+    elif type == 'Optional[int]':
+        return isinstance(value, int) or value is None
+    elif type == 'Optional[float]':
+        return isinstance(value, float) or isinstance(value, int) or value is None
+    else:
+        raise Exception(f"Unknown type in _parameter_value_is_consistent_with_type: {type}")

--- a/python/dendro/sdk/AppProcessor.py
+++ b/python/dendro/sdk/AppProcessor.py
@@ -314,7 +314,9 @@ _type_map = {
     'List[str]': List[str],
     'List[int]': List[int],
     'List[float]': List[float],
-    'List[bool]': List[bool]
+    'List[bool]': List[bool],
+    'Optional[int]': Union[int, None],
+    'Optional[float]': Union[float, None],
 }
 
 def _type_to_string(type: Any):

--- a/python/tests/mock_app/main.py
+++ b/python/tests/mock_app/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from typing import List
+from typing import List, Optional
 import time
 import os
 from dendro import BaseModel, Field
@@ -19,6 +19,7 @@ class MockProcessor1Context(BaseModel):
     text2: str = Field(description='Text 2')
     text3: str = Field(description='Text 3', default='xyz', json_schema_extra={'options': ['abc', 'xyz']})
     val1: float = Field(description='Value 1', default=1.0)
+    val2: Optional[float] = Field(description='Value 2 could be a float or it could be None')
     group: MockParameterGroup = Field(description='Group', default=MockParameterGroup())
     intentional_error: bool = Field(description='Intentional error', default=False)
 

--- a/python/tests/mock_app_2/main.py
+++ b/python/tests/mock_app_2/main.py
@@ -6,7 +6,7 @@ from dendro.sdk import App, ProcessorBase
 
 
 class MockProcessor2Context(BaseModel):
-    text1: str = Field(description='Text 1', default='abc')
+    text1: str = Field(description='Text 1')
 
 class MockProcessor2(ProcessorBase):
     name = 'mock-processor2'

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -283,6 +283,23 @@ async def test_integration(tmp_path):
         job_id_2 = resp.jobId
         assert job_id_2
 
+        # gui: Test not providing a required parameter
+        processor_name_2 = 'mock-processor2'
+        processor_spec_2 = compute_resource_spec_app_2.processors[0]
+        req = CreateJobRequest(
+            projectId=project2_id,
+            processorName=processor_name_2,
+            inputFiles=[],
+            outputFiles=[],
+            inputParameters=[
+            ],
+            processorSpec=processor_spec_2,
+            batchId=None,
+            dandiApiKey=None,
+        )
+        with pytest.raises(Exception):
+            _gui_post_api_request(url_path='/api/gui/jobs', data=_model_dump(req), github_access_token=github_access_token)
+
         # gui: Get job
         job = _get_job(job_id=job_id_1, github_access_token=github_access_token)
         assert job.projectId == project2_id

--- a/src/pages/ProjectPage/EditJobDefinitionWindow/EditJobDefinitionWindow.tsx
+++ b/src/pages/ProjectPage/EditJobDefinitionWindow/EditJobDefinitionWindow.tsx
@@ -460,8 +460,14 @@ const EditParameterValue: FunctionComponent<EditParameterValueProps> = ({paramet
     else if (type === 'int') {
         return <IntEdit value={value} setValue={setValue} setValid={setValid} />
     }
+    else if (type === 'Optional[int]') {
+        return <IntEdit value={value} setValue={setValue} setValid={setValid} optional={true} />
+    }
     else if (type === 'float') {
         return <FloatEdit value={value} setValue={setValue} setValid={setValid} />
+    }
+    else if (type === 'Optional[float]') {
+        return <FloatEdit value={value} setValue={setValue} setValid={setValid} optional={true} />
     }
     else if (type === 'bool') {
         setValid(true)
@@ -483,40 +489,56 @@ const EditParameterValue: FunctionComponent<EditParameterValueProps> = ({paramet
 
 type FloatEditProps = {
     value: any
-    setValue: (value: number) => void
+    setValue: (value: number | undefined) => void
     setValid: (valid: boolean) => void
+    optional?: boolean
 }
 
-const FloatEdit: FunctionComponent<FloatEditProps> = ({value, setValue, setValid}) => {
-    const [internalValue, setInternalValue] = useState<string | undefined>(undefined)
+const FloatEdit: FunctionComponent<FloatEditProps> = ({value, setValue, setValid, optional}) => {
+    const [internalValue, setInternalValue] = useState<string | undefined>(undefined) // value of undefined corresponds to internalValue of ''
     useEffect(() => {
-        if (isFloatType(value)) {
-            setInternalValue(old => {
-                if ((old !== undefined) && (stringIsValidFloat(old)) && (parseFloat(old) === value)) return old
-                return `${value}`
-            })
+        if ((value === undefined) && (optional)) {
+            setInternalValue('')
         }
-    }, [value])
+        else {
+            if (isFloatType(value)) {
+                setInternalValue(old => {
+                    if ((old !== undefined) && (stringIsValidFloat(old)) && (parseFloat(old) === value)) return old
+                    return `${value}`
+                })
+            }
+        }
+    }, [value, optional])
 
     useEffect(() => {
         if (internalValue === undefined) return
-        if (stringIsValidFloat(internalValue)) {
-            setValue(parseFloat(internalValue))
+        if ((optional) && (internalValue === '')) {
+            setValue(undefined)
             setValid(true)
         }
         else {
-            setValid(false)
+            if (stringIsValidFloat(internalValue)) {
+                setValue(parseFloat(internalValue))
+                setValid(true)
+            }
+            else {
+                setValid(false)
+            }
         }
-    }, [internalValue, setValue, setValid])
+    }, [internalValue, setValue, setValid, optional])
 
     const isValid = useMemo(() => {
         if (internalValue === undefined) return false
+        if ((optional) && (internalValue === '')) return true
         return stringIsValidFloat(internalValue)
-    }, [internalValue])
+    }, [internalValue, optional])
 
     return (
         <span className="FloatEdit">
             <input type="text" value={internalValue || ''} onChange={evt => {setInternalValue(evt.target.value)}} style={numInputStyle} />
+            {
+                isValid ? null : <span style={{color: 'red'}}>x</span>
+            }
             {
                 isValid ? null : <span style={{color: 'red'}}>x</span>
             }
@@ -535,36 +557,49 @@ function stringIsValidFloat(s: string) {
 
 type IntEditProps = {
     value: any
-    setValue: (value: number) => void
+    setValue: (value: number | undefined) => void
     setValid: (valid: boolean) => void
+    optional?: boolean
 }
 
-const IntEdit: FunctionComponent<IntEditProps> = ({value, setValue, setValid}) => {
-    const [internalValue, setInternalValue] = useState<string | undefined>(undefined)
+const IntEdit: FunctionComponent<IntEditProps> = ({value, setValue, setValid, optional}) => {
+    const [internalValue, setInternalValue] = useState<string | undefined>(undefined) // value of undefined corresponds to internalValue of ''
     useEffect(() => {
-        if (isIntType(value)) {
-            setInternalValue(old => {
-                if ((old !== undefined) && (stringIsValidInt(old)) && (parseInt(old) === value)) return old
-                return `${value}`
-            })
+        if ((value === undefined) && (optional)) {
+            setInternalValue('')
         }
-    }, [value])
+        else {
+            if (isIntType(value)) {
+                setInternalValue(old => {
+                    if ((old !== undefined) && (stringIsValidInt(old)) && (parseInt(old) === value)) return old
+                    return `${value}`
+                })
+            }
+        }
+    }, [value, optional])
 
     useEffect(() => {
         if (internalValue === undefined) return
-        if (stringIsValidInt(internalValue)) {
-            setValue(parseInt(internalValue))
+        if ((optional) && (internalValue === '')) {
+            setValue(undefined)
             setValid(true)
         }
         else {
-            setValid(false)
+            if (stringIsValidInt(internalValue)) {
+                setValue(parseInt(internalValue))
+                setValid(true)
+            }
+            else {
+                setValid(false)
+            }
         }
-    }, [internalValue, setValue, setValid])
+    }, [internalValue, setValue, setValid, optional])
 
     const isValid = useMemo(() => {
         if (internalValue === undefined) return false
+        if ((optional) && (internalValue === '')) return true
         return stringIsValidInt(internalValue)
-    }, [internalValue])
+    }, [internalValue, optional])
 
     return (
         <span className="IntEdit">


### PR DESCRIPTION
@luiztauffer 

Adding support for `Optional` parameters. Right now this only supports `Optional[int]` and `Optional[float]`. I figure that optional str can just be empty string, optional bool is probably not needed, and optional list can just be an empty list.

There is an example usage in one of the tests:

https://github.com/flatironinstitute/dendro/blob/optional-parameters/python/tests/mock_app/main.py