### PR TITLE
Refactor compute resource - Do not require CR restart

### DIFF
--- a/python/dendro/api_helpers/routers/gui/compute_resource_routes.py
+++ b/python/dendro/api_helpers/routers/gui/compute_resource_routes.py
@@ -1,5 +1,7 @@
 from typing import List
 import time
+
+from ...clients.pubsub import publish_pubsub_message
 from .... import BaseModel
 from fastapi import APIRouter, Header
 from ...services._crypto_keys import _verify_signature
@@ -72,6 +74,14 @@ async def set_compute_resource_apps(compute_resource_id, data: SetComputeResourc
         'apps': [_model_dump(app, exclude_none=True) for app in apps],
         'timestampModified': time.time()
     })
+
+    await publish_pubsub_message(
+        channel=compute_resource_id,
+        message={
+            'type': 'computeResourceAppsChanaged',
+            'computeResourceId': compute_resource_id
+        }
+    )
 
     return SetComputeResourceAppsResponse(success=True)
 

--- a/python/dendro/compute_resource/AppManager.py
+++ b/python/dendro/compute_resource/AppManager.py
@@ -1,0 +1,114 @@
+from typing import List, Optional, Union
+
+from ..sdk.App import App
+from ..common.dendro_types import DendroComputeResourceApp
+from ..common._api_request import _compute_resource_get_api_request, _compute_resource_put_api_request
+
+
+class AppManager:
+    def __init__(self, *,
+                 compute_resource_id: str,
+                 compute_resource_private_key: str,
+                 compute_resource_node_name: Optional[str],
+                 compute_resource_node_id: Optional[str]
+                ):
+        self._compute_resource_id = compute_resource_id
+        self._compute_resource_private_key = compute_resource_private_key
+        self._compute_resource_node_name = compute_resource_node_name
+        self._compute_resource_node_id = compute_resource_node_id
+
+        self._compute_resource_apps: List[DendroComputeResourceApp] = []
+        self._apps: List[App] = []
+
+    def update_apps(self):
+        ...
+    def find_app_with_processor(self, processor_name: str) -> Union[App, None]:
+        for app in self._apps:
+            for p in app._processors:
+                if p._name == processor_name:
+                    return app
+        return None
+    def _load_compute_resource_apps(self):
+        url_path = f'/api/compute_resource/compute_resources/{self._compute_resource_id}/apps'
+        resp = _compute_resource_get_api_request(
+            url_path=url_path,
+            compute_resource_id=self._compute_resource_id,
+            compute_resource_private_key=self._compute_resource_private_key,
+            compute_resource_node_name=self._compute_resource_node_name,
+            compute_resource_node_id=self._compute_resource_node_id
+        )
+
+        # It would be nice to do it this way, but we can't because we don't want to import stuff from the api here
+        # from ..api_helpers.routers.compute_resource.router import GetAppsResponse
+        # resp = GetAppsResponse(**resp)
+        # compute_resource_apps = resp.apps
+
+        # instead:
+        compute_resource_apps_from_response = resp['apps']
+        compute_resource_apps_from_response = [DendroComputeResourceApp(**app) for app in compute_resource_apps_from_response]
+        something_changed = False
+        for app in self._apps:
+            matching_cr_app = next((cr_app for cr_app in compute_resource_apps_from_response if _app_matches(app, cr_app)), None)
+            if not matching_cr_app:
+                assert app._spec_uri is not None, 'Unexpected: app has no spec uri'
+                self._unload_app(app._spec_uri)
+                something_changed = True
+        for cr_app_from_response in compute_resource_apps_from_response:
+            matching_app = next((app for app in self._apps if _app_matches(app, cr_app_from_response)), None)
+            if not matching_app:
+                self._load_app(cr_app_from_response)
+                something_changed = True
+        if something_changed:
+            # Report the compute resource spec
+            print('Reporting the compute resource spec')
+            url_path = f'/api/compute_resource/compute_resources/{self._compute_resource_id}/spec'
+            spec = {
+                'apps': [a._spec_dict for a in self._apps]
+            }
+            _compute_resource_put_api_request(
+                url_path=url_path,
+                compute_resource_id=self._compute_resource_id,
+                compute_resource_private_key=self._compute_resource_private_key,
+                data={
+                    'spec': spec
+                }
+            )
+    def _unload_app(self, spec_uri: str):
+        print(f'Unloading app {spec_uri}')
+        self._apps = [app for app in self._apps if app._spec_uri != spec_uri]
+    def _load_app(self, cr_app: DendroComputeResourceApp):
+        print(f'Loading app {cr_app.specUri}')
+        app = App.from_spec_uri(
+            spec_uri=cr_app.specUri,
+            aws_batch_opts=cr_app.awsBatch,
+            slurm_opts=cr_app.slurm
+        )
+        self._apps.append(app)
+
+        # print info about the app so we can see what's going on
+        s = []
+        if cr_app.awsBatch is not None:
+            if cr_app.slurm is not None:
+                print('WARNING: App has awsBatch opts but also has slurm opts')
+            s.append(f'awsBatchJobQueue: {cr_app.awsBatch.jobQueue}')
+            s.append(f'awsBatchJobDefinition: {cr_app.awsBatch.jobDefinition}')
+        if cr_app.slurm is not None:
+            slurm_cpus_per_task = cr_app.slurm.cpusPerTask
+            slurm_partition = cr_app.slurm.partition
+            slurm_time = cr_app.slurm.time
+            slurm_other_opts = cr_app.slurm.otherOpts
+            s.append(f'slurmCpusPerTask: {slurm_cpus_per_task}')
+            s.append(f'slurmPartition: {slurm_partition}')
+            s.append(f'slurmTime: {slurm_time}')
+            s.append(f'slurmOtherOpts: {slurm_other_opts}')
+        print(f'  {" | ".join(s)}')
+        print(f'  {len(app._processors)} processors')
+        print('')
+        print('')
+
+def _app_matches(app: App, cr_app: DendroComputeResourceApp) -> bool:
+    return (
+        app._spec_uri == cr_app.specUri and
+        app._aws_batch_opts == cr_app.awsBatch and
+        app._slurm_opts == cr_app.slurm
+    )

--- a/python/dendro/compute_resource/AppManager.py
+++ b/python/dendro/compute_resource/AppManager.py
@@ -21,14 +21,6 @@ class AppManager:
         self._apps: List[App] = []
 
     def update_apps(self):
-        ...
-    def find_app_with_processor(self, processor_name: str) -> Union[App, None]:
-        for app in self._apps:
-            for p in app._processors:
-                if p._name == processor_name:
-                    return app
-        return None
-    def _load_compute_resource_apps(self):
         url_path = f'/api/compute_resource/compute_resources/{self._compute_resource_id}/apps'
         resp = _compute_resource_get_api_request(
             url_path=url_path,
@@ -73,6 +65,12 @@ class AppManager:
                     'spec': spec
                 }
             )
+    def find_app_with_processor(self, processor_name: str) -> Union[App, None]:
+        for app in self._apps:
+            for p in app._processors:
+                if p._name == processor_name:
+                    return app
+        return None
     def _unload_app(self, spec_uri: str):
         print(f'Unloading app {spec_uri}')
         self._apps = [app for app in self._apps if app._spec_uri != spec_uri]

--- a/python/dendro/compute_resource/ComputeResourceException.py
+++ b/python/dendro/compute_resource/ComputeResourceException.py
@@ -1,0 +1,2 @@
+class ComputeResourceException(Exception):
+    pass

--- a/python/dendro/compute_resource/JobManager.py
+++ b/python/dendro/compute_resource/JobManager.py
@@ -1,0 +1,118 @@
+from typing import Dict, List, Optional, Union
+from .SlurmJobHandler import SlurmJobHandler
+from .AppManager import AppManager
+from ..common.dendro_types import DendroJob
+from ..sdk.App import App
+from ..sdk._run_job import _set_job_status
+from .ComputeResourceException import ComputeResourceException
+
+
+max_simultaneous_local_jobs = 2
+
+class JobManager:
+    def __init__(self, *,
+                 compute_resource_id: str,
+                 compute_resource_private_key: str,
+                 compute_resource_node_name: Optional[str],
+                 compute_resource_node_id: Optional[str],
+                 app_manager: AppManager
+                ):
+        self._compute_resource_id = compute_resource_id
+        self._compute_resource_private_key = compute_resource_private_key
+        self._compute_resource_node_name = compute_resource_node_name
+        self._compute_resource_node_id = compute_resource_node_id
+        self._app_manager = app_manager
+
+        # important to keep track of which jobs we attempted to start
+        # so that we don't attempt multiple times in the case where starting failed
+        self._attempted_to_start_job_ids = set()
+
+        self._slurm_job_handlers_by_processor: Dict[str, SlurmJobHandler] = {}
+    def handle_jobs(self, jobs: List[DendroJob]):
+        # Local jobs
+        local_jobs = [job for job in jobs if self._is_local_job(job)]
+        num_non_pending_local_jobs = len([job for job in local_jobs if job.status != 'pending'])
+        if num_non_pending_local_jobs < max_simultaneous_local_jobs:
+            pending_local_jobs = [job for job in local_jobs if job.status == 'pending']
+            pending_local_jobs = _sort_jobs_by_timestamp_created(pending_local_jobs)
+            num_to_start = min(max_simultaneous_local_jobs - num_non_pending_local_jobs, len(pending_local_jobs))
+            local_jobs_to_start = pending_local_jobs[:num_to_start]
+            for job in local_jobs_to_start:
+                self._start_job(job)
+
+        # AWS Batch jobs
+        aws_batch_jobs = [job for job in jobs if self._is_aws_batch_job(job)]
+        for job in aws_batch_jobs:
+            self._start_job(job)
+
+        # SLURM jobs
+        slurm_jobs = [job for job in jobs if self._is_slurm_job(job) and self._job_is_pending(job)]
+        for job in slurm_jobs:
+            processor_name = job.processorName
+            if processor_name not in self._slurm_job_handlers_by_processor:
+                app = self._app_manager.find_app_with_processor(processor_name)
+                if not app:
+                    raise ComputeResourceException(f'Could not find app for processor {processor_name}')
+                if not app._slurm_opts:
+                    raise ComputeResourceException(f'Unexpected: Could not find slurm opts for app {app._name}')
+                self._slurm_job_handlers_by_processor[processor_name] = SlurmJobHandler(job_manager=self, slurm_opts=app._slurm_opts)
+            self._slurm_job_handlers_by_processor[processor_name].add_job(job)
+    def do_work(self):
+        for slurm_job_handler in self._slurm_job_handlers_by_processor.values():
+            slurm_job_handler.do_work()
+    def _get_job_resource_type(self, job: DendroJob) -> Union[str, None]:
+        processor_name = job.processorName
+        app: Union[App, None] = self._app_manager.find_app_with_processor(processor_name)
+        if app is None:
+            return None
+        if app._aws_batch_opts is not None and app._aws_batch_opts.jobQueue is not None:
+            return 'aws_batch'
+        if app._slurm_opts is not None:
+            return 'slurm'
+        return 'local'
+    def _is_local_job(self, job: DendroJob) -> bool:
+        return self._get_job_resource_type(job) == 'local'
+
+    def _is_aws_batch_job(self, job: DendroJob) -> bool:
+        return self._get_job_resource_type(job) == 'aws_batch'
+
+    def _is_slurm_job(self, job: DendroJob) -> bool:
+        return self._get_job_resource_type(job) == 'slurm'
+
+    def _job_is_pending(self, job: DendroJob) -> bool:
+        return job.status == 'pending'
+    def _start_job(self, job: DendroJob, run_process: bool = True, return_shell_command: bool = False):
+        job_id = job.jobId
+        if job_id in self._attempted_to_start_job_ids:
+            return '' # see above comment about why this is necessary
+        self._attempted_to_start_job_ids.add(job_id)
+        job_private_key = job.jobPrivateKey
+        processor_name = job.processorName
+        app = self._app_manager.find_app_with_processor(processor_name)
+        if app is None:
+            msg = f'Could not find app with processor name {processor_name}'
+            print(msg)
+            _set_job_status(job_id=job_id, job_private_key=job_private_key, status='failed', error=msg)
+            return ''
+        try:
+            print(f'Starting job {job_id} {processor_name}')
+            from ._start_job import _start_job
+            return _start_job(
+                job_id=job_id,
+                job_private_key=job_private_key,
+                processor_name=processor_name,
+                app=app,
+                run_process=run_process,
+                return_shell_command=return_shell_command
+            )
+        except Exception as e: # pylint: disable=broad-except
+            # do a traceback
+            import traceback
+            traceback.print_exc()
+            msg = f'Failed to start job: {str(e)}'
+            print(msg)
+            _set_job_status(job_id=job_id, job_private_key=job_private_key, status='failed', error=msg)
+            return ''
+
+def _sort_jobs_by_timestamp_created(jobs: List[DendroJob]) -> List[DendroJob]:
+    return sorted(jobs, key=lambda job: job.timestampCreated)

--- a/python/dendro/compute_resource/JobManager.py
+++ b/python/dendro/compute_resource/JobManager.py
@@ -1,10 +1,11 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, TYPE_CHECKING
 from .SlurmJobHandler import SlurmJobHandler
-from .AppManager import AppManager
 from ..common.dendro_types import DendroJob
 from ..sdk.App import App
 from ..sdk._run_job import _set_job_status
 from .ComputeResourceException import ComputeResourceException
+if TYPE_CHECKING:
+    from .AppManager import AppManager
 
 
 max_simultaneous_local_jobs = 2
@@ -15,7 +16,7 @@ class JobManager:
                  compute_resource_private_key: str,
                  compute_resource_node_name: Optional[str],
                  compute_resource_node_id: Optional[str],
-                 app_manager: AppManager
+                 app_manager: 'AppManager'
                 ):
         self._compute_resource_id = compute_resource_id
         self._compute_resource_private_key = compute_resource_private_key

--- a/python/dendro/compute_resource/SlurmJobHandler.py
+++ b/python/dendro/compute_resource/SlurmJobHandler.py
@@ -5,12 +5,12 @@ import subprocess
 
 from ..mock import using_mock
 from ..common.dendro_types import ComputeResourceSlurmOpts, DendroJob
-from .start_compute_resource import Daemon
+from .JobManager import JobManager
 
 
 class SlurmJobHandler:
-    def __init__(self, daemon: Daemon, slurm_opts: ComputeResourceSlurmOpts):
-        self._daemon = daemon
+    def __init__(self, *, job_manager: JobManager, slurm_opts: ComputeResourceSlurmOpts):
+        self._job_manager = job_manager
         self._slurm_opts = slurm_opts
         self._jobs: List[DendroJob] = []
         self._job_ids = set()
@@ -52,7 +52,7 @@ class SlurmJobHandler:
             f.write('set -e\n')
             f.write('\n')
             for ii, job in enumerate(jobs):
-                cmd = self._daemon._start_job(job, run_process=False, return_shell_command=True)
+                cmd = self._job_manager._start_job(job, run_process=False, return_shell_command=True)
                 if cmd:
                     if not using_mock():
                         f.write(f'if [ "$SLURM_PROCID" == "{ii}" ]; then\n')

--- a/python/dendro/compute_resource/SlurmJobHandler.py
+++ b/python/dendro/compute_resource/SlurmJobHandler.py
@@ -1,15 +1,17 @@
-from typing import List
+from typing import List, TYPE_CHECKING
 import os
 import time
 import subprocess
 
 from ..mock import using_mock
 from ..common.dendro_types import ComputeResourceSlurmOpts, DendroJob
-from .JobManager import JobManager
+
+if TYPE_CHECKING:
+    from .JobManager import JobManager
 
 
 class SlurmJobHandler:
-    def __init__(self, *, job_manager: JobManager, slurm_opts: ComputeResourceSlurmOpts):
+    def __init__(self, *, job_manager: 'JobManager', slurm_opts: ComputeResourceSlurmOpts):
         self._job_manager = job_manager
         self._slurm_opts = slurm_opts
         self._jobs: List[DendroJob] = []

--- a/python/dendro/compute_resource/_start_job.py
+++ b/python/dendro/compute_resource/_start_job.py
@@ -51,8 +51,8 @@ def _start_job(*,
     assert hasattr(app, '_app_executable'), 'App does not have an executable path'
     app_executable: Union[str, None] = app._app_executable
     app_image: Union[str, None] = app._app_image
-    aws_batch_job_queue: Union[str, None] = app._aws_batch_job_queue
-    aws_batch_job_definition: Union[str, None] = app._aws_batch_job_definition
+    aws_batch_job_queue: Union[str, None] = app._aws_batch_opts.jobQueue if app._aws_batch_opts else None
+    aws_batch_job_definition: Union[str, None] = app._aws_batch_opts.jobDefinition if app._aws_batch_opts else None
     slurm_opts: Union[ComputeResourceSlurmOpts, None] = app._slurm_opts
 
     # default for app_executable

--- a/python/dendro/compute_resource/start_compute_resource.py
+++ b/python/dendro/compute_resource/start_compute_resource.py
@@ -31,6 +31,7 @@ class Daemon:
             compute_resource_node_name=self._node_name,
             compute_resource_node_id=self._node_id
         )
+        print('-------------------------------------------------------------------------- update_apps')
         self._app_manager.update_apps()
 
         self._job_manager = JobManager(

--- a/python/dendro/compute_resource/start_compute_resource.py
+++ b/python/dendro/compute_resource/start_compute_resource.py
@@ -1,23 +1,16 @@
-from typing import List, Dict, Optional, Union
+from typing import Optional
 import os
 import yaml
 import time
 from pathlib import Path
 import shutil
 import multiprocessing
-from ..common._api_request import _compute_resource_get_api_request, _compute_resource_put_api_request
+from ..common._api_request import _compute_resource_get_api_request
 from .register_compute_resource import env_var_keys
-from ..sdk.App import App
-from ..sdk._run_job import _set_job_status
 from .PubsubClient import PubsubClient
-from ..common.dendro_types import DendroComputeResourceApp, DendroJob
+from ..common.dendro_types import DendroJob
 from ..mock import using_mock
 
-
-max_simultaneous_local_jobs = 2
-
-class ComputeResourceException(Exception):
-    pass
 
 class Daemon:
     def __init__(self):
@@ -29,44 +22,25 @@ class Daemon:
             raise ValueError('Compute resource has not been initialized in this directory, and the environment variable COMPUTE_RESOURCE_ID is not set.')
         if self._compute_resource_private_key is None:
             raise ValueError('Compute resource has not been initialized in this directory, and the environment variable COMPUTE_RESOURCE_PRIVATE_KEY is not set.')
-        self._apps: List[App] = _load_apps(
+
+        from .AppManager import AppManager # avoid circular import
+        self._app_manager = AppManager(
             compute_resource_id=self._compute_resource_id,
             compute_resource_private_key=self._compute_resource_private_key,
             compute_resource_node_name=self._node_name,
             compute_resource_node_id=self._node_id
         )
+        self._app_manager.update_apps()
 
-        # important to keep track of which jobs we attempted to start
-        # so that we don't attempt multiple times in the case where starting failed
-        self._attempted_to_start_job_ids = set()
-
-        print(f'Loaded apps: {", ".join([app._name for app in self._apps])}')
-
-        from .SlurmJobHandler import SlurmJobHandler # we don't want a circular import
-        self._slurm_job_handlers_by_processor: Dict[str, SlurmJobHandler] = {}
-        for app in self._apps:
-            for processor in app._processors:
-                if app._slurm_opts is not None:
-                    self._slurm_job_handlers_by_processor[processor._name] = SlurmJobHandler(self, app._slurm_opts)
-
-        spec_apps = []
-        for app in self._apps:
-            spec_apps.append(app.get_spec())
-
-        # Report the compute resource spec
-        print('Reporting the compute resource spec')
-        url_path = f'/api/compute_resource/compute_resources/{self._compute_resource_id}/spec'
-        spec = {
-            'apps': spec_apps
-        }
-        _compute_resource_put_api_request(
-            url_path=url_path,
+        from .JobManager import JobManager # avoid circular import
+        self._job_manager = JobManager(
             compute_resource_id=self._compute_resource_id,
             compute_resource_private_key=self._compute_resource_private_key,
-            data={
-                'spec': spec
-            }
+            compute_resource_node_name=self._node_name,
+            compute_resource_node_id=self._node_id,
+            app_manager=self._app_manager
         )
+
         print('Getting pubsub info')
         pubsub_subscription = get_pubsub_subscription(
             compute_resource_id=self._compute_resource_id,
@@ -108,12 +82,13 @@ class Daemon:
                     need_to_handle_jobs = True
                 if msg['type'] == 'jobStatusChaged':
                     need_to_handle_jobs = True
+                if msg['type'] == 'computeResourceAppsChanaged':
+                    self._app_manager.update_apps()
             if need_to_handle_jobs:
                 timer_handle_jobs = time.time()
                 self._handle_jobs()
 
-            for slurm_job_handler in self._slurm_job_handlers_by_processor.values():
-                slurm_job_handler.do_work()
+            self._job_manager.do_work()
 
             overall_elapsed = time.time() - overall_timer
             if timeout is not None and overall_elapsed > timeout:
@@ -123,7 +98,6 @@ class Daemon:
                 time.sleep(0.01 / time_scale_factor) # for the first few seconds we can sleep for a short time (useful for testing)
             else:
                 time.sleep(2 / time_scale_factor)
-
     def _handle_jobs(self):
         url_path = f'/api/compute_resource/compute_resources/{self._compute_resource_id}/unfinished_jobs'
         if not self._compute_resource_id:
@@ -138,159 +112,8 @@ class Daemon:
             compute_resource_node_id=self._node_id
         )
         jobs = resp['jobs']
-        jobs = [DendroJob(**job) for job in jobs] # validation
-
-        # Local jobs
-        local_jobs = [job for job in jobs if self._is_local_job(job)]
-        num_non_pending_local_jobs = len([job for job in local_jobs if job.status != 'pending'])
-        if num_non_pending_local_jobs < max_simultaneous_local_jobs:
-            pending_local_jobs = [job for job in local_jobs if job.status == 'pending']
-            pending_local_jobs = _sort_jobs_by_timestamp_created(pending_local_jobs)
-            num_to_start = min(max_simultaneous_local_jobs - num_non_pending_local_jobs, len(pending_local_jobs))
-            local_jobs_to_start = pending_local_jobs[:num_to_start]
-            for job in local_jobs_to_start:
-                self._start_job(job)
-
-        # AWS Batch jobs
-        aws_batch_jobs = [job for job in jobs if self._is_aws_batch_job(job)]
-        for job in aws_batch_jobs:
-            self._start_job(job)
-
-        # SLURM jobs
-        slurm_jobs = [job for job in jobs if self._is_slurm_job(job) and self._job_is_pending(job)]
-        for job in slurm_jobs:
-            processor_name = job.processorName
-            if processor_name not in self._slurm_job_handlers_by_processor:
-                raise ComputeResourceException(f'Unexpected: Could not find slurm job handler for processor {processor_name}')
-            self._slurm_job_handlers_by_processor[processor_name].add_job(job)
-
-    def _get_job_resource_type(self, job: DendroJob) -> Union[str, None]:
-        processor_name = job.processorName
-        app: Union[App, None] = self._find_app_with_processor(processor_name)
-        if app is None:
-            return None
-        if app._aws_batch_job_queue is not None:
-            return 'aws_batch'
-        if app._slurm_opts is not None:
-            return 'slurm'
-        return 'local'
-
-    def _is_local_job(self, job: DendroJob) -> bool:
-        return self._get_job_resource_type(job) == 'local'
-
-    def _is_aws_batch_job(self, job: DendroJob) -> bool:
-        return self._get_job_resource_type(job) == 'aws_batch'
-
-    def _is_slurm_job(self, job: DendroJob) -> bool:
-        return self._get_job_resource_type(job) == 'slurm'
-
-    def _job_is_pending(self, job: DendroJob) -> bool:
-        return job.status == 'pending'
-
-    def _start_job(self, job: DendroJob, run_process: bool = True, return_shell_command: bool = False):
-        job_id = job.jobId
-        if job_id in self._attempted_to_start_job_ids:
-            return '' # see above comment about why this is necessary
-        self._attempted_to_start_job_ids.add(job_id)
-        job_private_key = job.jobPrivateKey
-        processor_name = job.processorName
-        app = self._find_app_with_processor(processor_name)
-        if app is None:
-            msg = f'Could not find app with processor name {processor_name}'
-            print(msg)
-            _set_job_status(job_id=job_id, job_private_key=job_private_key, status='failed', error=msg)
-            return ''
-        try:
-            print(f'Starting job {job_id} {processor_name}')
-            from ._start_job import _start_job
-            return _start_job(
-                job_id=job_id,
-                job_private_key=job_private_key,
-                processor_name=processor_name,
-                app=app,
-                run_process=run_process,
-                return_shell_command=return_shell_command
-            )
-        except Exception as e: # pylint: disable=broad-except
-            # do a traceback
-            import traceback
-            traceback.print_exc()
-            msg = f'Failed to start job: {str(e)}'
-            print(msg)
-            _set_job_status(job_id=job_id, job_private_key=job_private_key, status='failed', error=msg)
-            return ''
-
-    def _find_app_with_processor(self, processor_name: str) -> Union[App, None]:
-        for app in self._apps:
-            for p in app._processors:
-                if p._name == processor_name:
-                    return app
-        return None
-
-def _load_apps(*, compute_resource_id: str, compute_resource_private_key: str, compute_resource_node_name: Optional[str] = None, compute_resource_node_id: Optional[str] = None) -> List[App]:
-    url_path = f'/api/compute_resource/compute_resources/{compute_resource_id}/apps'
-    resp = _compute_resource_get_api_request(
-        url_path=url_path,
-        compute_resource_id=compute_resource_id,
-        compute_resource_private_key=compute_resource_private_key,
-        compute_resource_node_name=compute_resource_node_name,
-        compute_resource_node_id=compute_resource_node_id
-    )
-
-    # It would be nice to do it this way, but we can't because we don't want to import stuff from the api here
-    # from ..api_helpers.routers.compute_resource.router import GetAppsResponse
-    # resp = GetAppsResponse(**resp)
-    # compute_resource_apps = resp.apps
-
-    # instead:
-    compute_resource_apps = resp['apps']
-    compute_resource_apps = [DendroComputeResourceApp(**app) for app in compute_resource_apps]
-
-    return _load_apps_from_compute_resource_apps(compute_resource_apps)
-
-def _load_apps_from_compute_resource_apps(compute_resource_apps: List[DendroComputeResourceApp]) -> List[App]:
-    ret = []
-    for a in compute_resource_apps:
-        container = a.container
-        aws_batch_opts = a.awsBatch
-        slurm_opts = a.slurm
-        s = []
-        if container is not None:
-            s.append(f'container: {container}')
-        if aws_batch_opts is not None:
-            if slurm_opts is not None:
-                raise ComputeResourceException('App has awsBatch opts but also has slurm opts')
-            aws_batch_job_queue = aws_batch_opts.jobQueue
-            aws_batch_job_definition = aws_batch_opts.jobDefinition
-            s.append(f'awsBatchJobQueue: {aws_batch_job_queue}')
-            s.append(f'awsBatchJobDefinition: {aws_batch_job_definition}')
-        else:
-            aws_batch_job_queue = None
-            aws_batch_job_definition = None
-        if slurm_opts is not None:
-            slurm_cpus_per_task = slurm_opts.cpusPerTask
-            slurm_partition = slurm_opts.partition
-            slurm_time = slurm_opts.time
-            slurm_other_opts = slurm_opts.otherOpts
-            s.append(f'slurmCpusPerTask: {slurm_cpus_per_task}')
-            s.append(f'slurmPartition: {slurm_partition}')
-            s.append(f'slurmTime: {slurm_time}')
-            s.append(f'slurmOtherOpts: {slurm_other_opts}')
-        else:
-            slurm_cpus_per_task = None
-            slurm_partition = None
-            slurm_time = None
-            slurm_other_opts = None
-        print(f'Loading app {a.specUri} | {" | ".join(s)}')
-        app = App.from_spec_uri(
-            spec_uri=a.specUri,
-            aws_batch_job_queue=aws_batch_job_queue,
-            aws_batch_job_definition=aws_batch_job_definition,
-            slurm_opts=slurm_opts
-        )
-        print(f'  {len(app._processors)} processors')
-        ret.append(app)
-    return ret
+        jobs = [DendroJob(**job) for job in jobs]
+        self._job_manager.handle_jobs(jobs)
 
 def start_compute_resource(dir: str, *, timeout: Optional[float] = None, cleanup_old_jobs=True): # timeout is used for testing
     config_fname = os.path.join(dir, '.dendro-compute-resource-node.yaml')
@@ -315,9 +138,6 @@ def get_pubsub_subscription(*, compute_resource_id: str, compute_resource_privat
         compute_resource_node_id=compute_resource_node_id
     )
     return resp['subscription']
-
-def _sort_jobs_by_timestamp_created(jobs: List[DendroJob]) -> List[DendroJob]:
-    return sorted(jobs, key=lambda job: job.timestampCreated)
 
 def _cleanup_old_job_working_directories(dir: str):
     """Delete working dirs that are more than 24 hours old"""

--- a/python/dendro/compute_resource/start_compute_resource.py
+++ b/python/dendro/compute_resource/start_compute_resource.py
@@ -10,6 +10,8 @@ from .register_compute_resource import env_var_keys
 from .PubsubClient import PubsubClient
 from ..common.dendro_types import DendroJob
 from ..mock import using_mock
+from .AppManager import AppManager
+from .JobManager import JobManager
 
 
 class Daemon:
@@ -23,7 +25,6 @@ class Daemon:
         if self._compute_resource_private_key is None:
             raise ValueError('Compute resource has not been initialized in this directory, and the environment variable COMPUTE_RESOURCE_PRIVATE_KEY is not set.')
 
-        from .AppManager import AppManager # avoid circular import
         self._app_manager = AppManager(
             compute_resource_id=self._compute_resource_id,
             compute_resource_private_key=self._compute_resource_private_key,
@@ -32,7 +33,6 @@ class Daemon:
         )
         self._app_manager.update_apps()
 
-        from .JobManager import JobManager # avoid circular import
         self._job_manager = JobManager(
             compute_resource_id=self._compute_resource_id,
             compute_resource_private_key=self._compute_resource_private_key,


### PR DESCRIPTION
@luiztauffer

Here I refactored the compute resource daemon in order to implement the scheme where we do not need to restart the compute resource for changes in the app configuration (from the frontend) to take effect.

Separated out the daemon into 3 classes: Daemon, AppManager, and JobManager

When the apps are changed in the frontend, a pubsub message is sent, and that's when the app manager knows to reload the apps.

TODO: reset the slurm job handler when an app is reloaded.