### PR TITLE
implement DENDRO_JOB_CLEANUP_DIR

### DIFF
--- a/python/dendro/compute_resource/_start_job.py
+++ b/python/dendro/compute_resource/_start_job.py
@@ -81,16 +81,22 @@ def _start_job(*,
             raise JobException(f'Error running job in AWS Batch: {e}') from e
         return ''
 
-    # Note for future: it is not necessary to use a working dir if the job is to run in a container
+    # WARNING!!! The working_dir is going to get cleaned up after the job is finished
+    # so it's very important to not set the working directory to a directory that is
+    # used for other purposes
     working_dir = os.getcwd() + '/jobs/' + job_id
     os.makedirs(working_dir, exist_ok=True)
 
+    # for safety, verify that cleanup directory is as expected
+    dendro_job_cleanup_dir = working_dir
+    assert dendro_job_cleanup_dir.endswith('/jobs/' + job_id), f'Unexpected dendro_job_cleanup_dir: {dendro_job_cleanup_dir}'
     env_vars = {
         'PYTHONUNBUFFERED': '1',
         'JOB_ID': job_id,
         'JOB_PRIVATE_KEY': job_private_key,
         'APP_EXECUTABLE': app_executable,
-        'DENDRO_URL': 'https://dendro.vercel.app'
+        'DENDRO_URL': 'https://dendro.vercel.app',
+        'DENDRO_JOB_CLEANUP_DIR': dendro_job_cleanup_dir # see the warning above
     }
     kachery_cloud_client_id, kachery_cloud_private_key = _get_kachery_cloud_credentials()
     if kachery_cloud_client_id is not None:


### PR DESCRIPTION
@luiztauffer This is to address https://github.com/flatironinstitute/dendro/issues/63

For AWS Batch, you will need to set DENDRO_JOB_CLEANUP_DIR env variable to the directory on the EFS that you want to be cleaned up after the job completes. Note that one small log file will not be deleted.

There will be two processes running in the container: a parent and a child. The child is what actually runs the processor. The parent is monitoring the child. If the child crashes, we should be okay and the files will get cleaned up. We don't expect the parent to crash... there is a try/finally, but I suppose it could happen.

One thing to consider: what if there is a timeout limit on the job? In the case that the container is closed by a timeout trigger, then of course the files will not get removed.