### PR TITLE
dendro api key and submit_job from python

### DIFF
--- a/python/dendro/api_helpers/routers/client/router.py
+++ b/python/dendro/api_helpers/routers/client/router.py
@@ -6,6 +6,7 @@ from ...clients.db import fetch_project, fetch_project_files, fetch_project_jobs
 from ..common import api_route_wrapper
 from ....common.dendro_types import CreateJobRequest, CreateJobResponse, DendroComputeResource
 from ..gui.create_job_route import create_job_handler
+from ...core.settings import get_settings
 
 router = APIRouter()
 
@@ -23,6 +24,8 @@ async def get_project(project_id) -> GetProjectResponse:
     project = await fetch_project(project_id)
     if project is None:
         raise ProjectError(f"No project with ID {project_id}")
+    if not project.computeResourceId:
+        project.computeResourceId = get_settings().DEFAULT_COMPUTE_RESOURCE_ID
     return GetProjectResponse(project=project, success=True)
 
 # get project files
@@ -55,7 +58,8 @@ async def create_job(
 ) -> CreateJobResponse:
     return await create_job_handler(
         data=data,
-        dendro_api_key=dendro_api_key
+        dendro_api_key=dendro_api_key,
+        github_access_token=None
     )
 
 # get compute resource

--- a/python/dendro/api_helpers/routers/gui/_authenticate_gui_request.py
+++ b/python/dendro/api_helpers/routers/gui/_authenticate_gui_request.py
@@ -3,9 +3,11 @@ import time
 import aiohttp
 import uuid
 from ..common import AuthException
+from ...clients.db import fetch_user_for_dendro_api_key
 
 
-_user_ids_for_access_tokens = {} # github access token -> {user_id: string, timestamp: float}
+_user_ids_for_github_access_tokens = {} # github access token -> {user_id: string, timestamp: float}
+_user_ids_for_dendro_api_keys = {} # dendro api key -> {user_id: string, timestamp: float}
 
 _mock_github_access_tokens: List[str] = []
 def _create_mock_github_access_token():
@@ -13,31 +15,53 @@ def _create_mock_github_access_token():
     _mock_github_access_tokens.append(token)
     return token
 
-async def _authenticate_gui_request(github_access_token: str, *, raise_on_not_authenticated) -> Union[str, None]:
+async def _authenticate_gui_request(*,
+    github_access_token: Union[str, None] = None,
+    dendro_api_key: Union[str, None] = None,
+    raise_on_not_authenticated: bool
+) -> Union[str, None]:
     try:
-        if not github_access_token:
-            raise AuthException('User is not authenticated')
-        if github_access_token in _user_ids_for_access_tokens:
-            a = _user_ids_for_access_tokens[github_access_token]
-            elapsed = time.time() - a['timestamp']
-            if elapsed > 60 * 60: # one hour
-                del _user_ids_for_access_tokens[github_access_token] # pragma: no cover
+        if github_access_token:
+            if github_access_token in _user_ids_for_github_access_tokens:
+                a = _user_ids_for_github_access_tokens[github_access_token]
+                elapsed = time.time() - a['timestamp']
+                if elapsed > 60 * 60: # one hour
+                    del _user_ids_for_github_access_tokens[github_access_token] # pragma: no cover
+                else:
+                    return a['user_id']
+            if not github_access_token.startswith('mock:'):
+                user_id = await _get_user_id_for_access_token(github_access_token)
+                if not user_id:
+                    raise AuthException('Invalid github access token')
+                user_id = 'github|' + user_id # pragma: no cover
             else:
-                return a['user_id']
-        if not github_access_token.startswith('mock:'):
-            user_id = await _get_user_id_for_access_token(github_access_token)
-            if not user_id:
-                raise AuthException('Invalid github access token')
-            user_id = 'github|' + user_id # pragma: no cover
+                if github_access_token not in _mock_github_access_tokens:
+                    raise AuthException('Invalid mock github access token')
+                user_id = 'github|' + github_access_token[len('mock:'):]
+            _user_ids_for_github_access_tokens[github_access_token] = {
+                'user_id': user_id,
+                'timestamp': time.time()
+            }
+            return user_id
+        elif dendro_api_key:
+            if dendro_api_key in _user_ids_for_dendro_api_keys:
+                a = _user_ids_for_dendro_api_keys[dendro_api_key]
+                elapsed = time.time() - a['timestamp']
+                if elapsed > 60 * 1: # one minute (the api key might get revoked so we don't want to cache it for too long)
+                    del _user_ids_for_dendro_api_keys[dendro_api_key]
+                else:
+                    return a['user_id']
+            user = await fetch_user_for_dendro_api_key(dendro_api_key)
+            assert user.dendroApiKey == dendro_api_key
+            assert user.userId
+            user_id = user.userId
+            _user_ids_for_dendro_api_keys[dendro_api_key] = {
+                'user_id': user_id,
+                'timestamp': time.time()
+            }
+            return user_id
         else:
-            if github_access_token not in _mock_github_access_tokens:
-                raise AuthException('Invalid mock github access token')
-            user_id = 'github|' + github_access_token[len('mock:'):]
-        _user_ids_for_access_tokens[github_access_token] = {
-            'user_id': user_id,
-            'timestamp': time.time()
-        }
-        return user_id
+            raise AuthException('User is not authenticated')
     except AuthException as e:
         if raise_on_not_authenticated:
             raise e

--- a/python/dendro/api_helpers/routers/gui/compute_resource_routes.py
+++ b/python/dendro/api_helpers/routers/gui/compute_resource_routes.py
@@ -42,7 +42,7 @@ class GetComputeResourcesResponse(BaseModel):
 @api_route_wrapper
 async def get_compute_resources(github_access_token: str = Header(...)):
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     compute_resources = await fetch_compute_resources_for_user(user_id)
@@ -60,7 +60,7 @@ class SetComputeResourceAppsResponse(BaseModel):
 @api_route_wrapper
 async def set_compute_resource_apps(compute_resource_id, data: SetComputeResourceAppsRequest, github_access_token: str = Header(...)) -> SetComputeResourceAppsResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     # parse the request
@@ -95,7 +95,7 @@ class DeleteComputeResourceResponse(BaseModel):
 @api_route_wrapper
 async def delete_compute_resource(compute_resource_id, github_access_token: str = Header(...)) -> DeleteComputeResourceResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     compute_resource = await fetch_compute_resource(compute_resource_id, raise_on_not_found=True)
@@ -148,7 +148,7 @@ class RegisterComputeResourceResponse(BaseModel):
 @api_route_wrapper
 async def register_compute_resource(data: RegisterComputeResourceRequest, github_access_token: str = Header(...)) -> RegisterComputeResourceResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     # parse the request
@@ -173,7 +173,7 @@ class GetJobsForComputeResourceResponse(BaseModel):
 @api_route_wrapper
 async def get_jobs_for_compute_resource(compute_resource_id, github_access_token: str = Header(...)) -> GetJobsForComputeResourceResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     compute_resource = await fetch_compute_resource(compute_resource_id, raise_on_not_found=True)

--- a/python/dendro/api_helpers/routers/gui/create_job_route.py
+++ b/python/dendro/api_helpers/routers/gui/create_job_route.py
@@ -27,9 +27,17 @@ class CreateJobResponse(BaseModel):
 
 @router.post("/jobs")
 @api_route_wrapper
-async def create_job_handler(data: CreateJobRequest, github_access_token: str = Header(...)) -> CreateJobResponse:
+async def create_job_handler(
+    data: CreateJobRequest,
+    github_access_token: Union[str, None] = Header(...),
+    dendro_api_key: Union[str, None] = Header(...)
+) -> CreateJobResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(
+        github_access_token=github_access_token,
+        dendro_api_key=dendro_api_key,
+        raise_on_not_authenticated=True
+    )
     assert user_id
 
     # parse the request

--- a/python/dendro/api_helpers/routers/gui/create_job_route.py
+++ b/python/dendro/api_helpers/routers/gui/create_job_route.py
@@ -1,29 +1,16 @@
-from typing import Union, List
-from .... import BaseModel
+from typing import Union
 from fastapi import APIRouter, Header
 
 from ._authenticate_gui_request import _authenticate_gui_request
-from ...services.gui.create_job import create_job, CreateJobRequestInputFile, CreateJobRequestOutputFile, CreateJobRequestInputParameter
-from ....common.dendro_types import ComputeResourceSpecProcessor
+from ...services.gui.create_job import create_job
 from ..common import api_route_wrapper
+
+from ....common.dendro_types import CreateJobRequest, CreateJobResponse
 
 
 router = APIRouter()
 
 # create job
-class CreateJobRequest(BaseModel):
-    projectId: str
-    processorName: str
-    inputFiles: List[CreateJobRequestInputFile]
-    outputFiles: List[CreateJobRequestOutputFile]
-    inputParameters: List[CreateJobRequestInputParameter]
-    processorSpec: ComputeResourceSpecProcessor
-    batchId: Union[str, None] = None
-    dandiApiKey: Union[str, None] = None
-
-class CreateJobResponse(BaseModel):
-    jobId: str
-    success: bool
 
 @router.post("/jobs")
 @api_route_wrapper

--- a/python/dendro/api_helpers/routers/gui/create_job_route.py
+++ b/python/dendro/api_helpers/routers/gui/create_job_route.py
@@ -29,8 +29,8 @@ class CreateJobResponse(BaseModel):
 @api_route_wrapper
 async def create_job_handler(
     data: CreateJobRequest,
-    github_access_token: Union[str, None] = Header(...),
-    dendro_api_key: Union[str, None] = Header(...)
+    github_access_token: Union[str, None] = Header(None),
+    dendro_api_key: Union[str, None] = Header(None)
 ) -> CreateJobResponse:
     # authenticate the request
     user_id = await _authenticate_gui_request(

--- a/python/dendro/api_helpers/routers/gui/file_routes.py
+++ b/python/dendro/api_helpers/routers/gui/file_routes.py
@@ -51,7 +51,7 @@ class SetFileResponse(BaseModel):
 @api_route_wrapper
 async def set_file(project_id, file_name, data: SetFileRequest, github_access_token: str = Header(...)):
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     # parse the request
@@ -79,7 +79,7 @@ class DeleteFileResponse(BaseModel):
 @api_route_wrapper
 async def delete_file(project_id, file_name, github_access_token: str = Header(...)):
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     project = await fetch_project(project_id)
@@ -110,7 +110,7 @@ class CreateFileAndInitiateUploadResponse(BaseModel):
 async def create_file_and_initiate_upload(project_id, data: CreateFileAndInitiateUploadRequest, github_access_token: str = Header(...)):
     # Generate a signed URL for uploading a file to the output bucket and set the file in the project.
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     # parse the request

--- a/python/dendro/api_helpers/routers/gui/job_routes.py
+++ b/python/dendro/api_helpers/routers/gui/job_routes.py
@@ -33,7 +33,7 @@ class DeleteJobResponse(BaseModel):
 @api_route_wrapper
 async def delete_job(job_id, github_access_token: str = Header(...)) -> DeleteJobResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     job = await fetch_job(job_id, raise_on_not_found=True)

--- a/python/dendro/api_helpers/routers/gui/project_routes.py
+++ b/python/dendro/api_helpers/routers/gui/project_routes.py
@@ -36,7 +36,7 @@ class GetProjectsResponse(BaseModel):
 @api_route_wrapper
 async def get_projects(github_access_token: str = Header(...), tag: Optional[str] = None):
     if tag is None:
-        user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=False)
+        user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=False)
         # note: user may be None if they are not authenticated
         projects = await fetch_projects_for_user(user_id)
         return GetProjectsResponse(projects=projects, success=True)
@@ -56,7 +56,7 @@ class CreateProjectResponse(BaseModel):
 @api_route_wrapper
 async def create_project(data: CreateProjectRequest, github_access_token: str = Header(...)) -> CreateProjectResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     # parse the request
@@ -91,7 +91,7 @@ class SetProjectNameResponse(BaseModel):
 @api_route_wrapper
 async def set_project_name(project_id, data: SetProjectNameRequest, github_access_token: str = Header(...)) -> SetProjectNameResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     project = await fetch_project(project_id, raise_on_not_found=True)
@@ -120,7 +120,7 @@ class SetProjectDescriptionResponse(BaseModel):
 @api_route_wrapper
 async def set_project_description(project_id, data: SetProjectDescriptionRequest, github_access_token: str = Header(...)) -> SetProjectDescriptionResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     project = await fetch_project(project_id, raise_on_not_found=True)
@@ -149,7 +149,7 @@ class SetProjectTagsResponse(BaseModel):
 @api_route_wrapper
 async def set_project_tags(project_id, data: SetProjectTagsRequest, github_access_token: str = Header(...)) -> SetProjectTagsResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     project = await fetch_project(project_id, raise_on_not_found=True)
@@ -175,7 +175,7 @@ class DeleteProjectResponse(BaseModel):
 @api_route_wrapper
 async def delete_project(project_id, github_access_token: str = Header(...)) -> DeleteProjectResponse:
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     project = await fetch_project(project_id, raise_on_not_found=True)
@@ -209,7 +209,7 @@ class SetProjectPubliclyReadableResponse(BaseModel):
 @api_route_wrapper
 async def set_project_public(project_id, data: SetProjectPubliclyReadableRequest, github_access_token: str = Header(...)):
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     project = await fetch_project(project_id, raise_on_not_found=True)
@@ -238,7 +238,7 @@ class SetProjectComputeResourceIdResponse(BaseModel):
 @api_route_wrapper
 async def set_project_compute_resource_id(project_id, data: SetProjectComputeResourceIdRequest, github_access_token: str = Header(...)):
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     project = await fetch_project(project_id, raise_on_not_found=True)
@@ -267,7 +267,7 @@ class SetProjectUsersResponse(BaseModel):
 @api_route_wrapper
 async def set_project_users(project_id, data: SetProjectUsersRequest, github_access_token: str = Header(...)):
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     project = await fetch_project(project_id, raise_on_not_found=True)
@@ -294,7 +294,7 @@ class AdminGetAllProjectsResponse(BaseModel):
 @api_route_wrapper
 async def admin_get_all_projects(github_access_token: str = Header(...)):
     # authenticate the request
-    user_id = await _authenticate_gui_request(github_access_token, raise_on_not_authenticated=True)
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
     assert user_id
 
     ADMIN_USER_IDS_JSON = os.getenv('ADMIN_USER_IDS', '[]')

--- a/python/dendro/api_helpers/routers/gui/router.py
+++ b/python/dendro/api_helpers/routers/gui/router.py
@@ -5,6 +5,7 @@ from .compute_resource_routes import router as compute_resource_router
 from .file_routes import router as file_router
 from .job_routes import router as job_router
 from .github_auth_routes import router as github_auth_router
+from .user_routes import router as user_router
 
 router = APIRouter()
 
@@ -14,3 +15,4 @@ router.include_router(compute_resource_router, prefix="/compute_resources")
 router.include_router(file_router)
 router.include_router(job_router, prefix="/jobs")
 router.include_router(github_auth_router)
+router.include_router(user_router, prefix="/users")

--- a/python/dendro/api_helpers/routers/gui/user_routes.py
+++ b/python/dendro/api_helpers/routers/gui/user_routes.py
@@ -1,0 +1,29 @@
+import hashlib
+import uuid
+from fastapi import APIRouter, Header
+from pydantic import BaseModel
+from ..common import api_route_wrapper
+from ._authenticate_gui_request import _authenticate_gui_request
+from ...clients.db import set_dendro_api_key_for_user
+
+
+router = APIRouter()
+
+class CreateDendroApiKeyResponse(BaseModel):
+    dendroApiKey: str
+    success: bool
+
+@router.post("/{user_id}/dendro_api_key")
+@api_route_wrapper
+async def create_dendro_api_key(user_id, github_access_token: str = Header(...)):
+    # authenticate the request
+    user_id = await _authenticate_gui_request(github_access_token=github_access_token, raise_on_not_authenticated=True)
+    assert user_id
+
+    # create the api key as the sha1 hash a of uuid
+    new_dendro_api_key = hashlib.sha1(str(uuid.uuid4()).encode('utf-8')).hexdigest()
+
+    # set the api key for the user
+    await set_dendro_api_key_for_user(user_id, new_dendro_api_key)
+
+    return CreateDendroApiKeyResponse(dendroApiKey=new_dendro_api_key, success=True)

--- a/python/dendro/api_helpers/services/gui/create_job.py
+++ b/python/dendro/api_helpers/services/gui/create_job.py
@@ -1,6 +1,5 @@
 import time
 from typing import Union, List, Any
-from .... import BaseModel
 from ....common.dendro_types import ComputeResourceSpecProcessor, DendroJobInputFile, DendroJobOutputFile, DendroJob, DendroJobInputParameter
 from ...clients.db import fetch_project, fetch_file, delete_file, fetch_project_jobs, delete_job, insert_job
 from ...core._get_project_role import _check_user_can_edit_project
@@ -8,18 +7,7 @@ from ...core._create_random_id import _create_random_id
 from ...clients.pubsub import publish_pubsub_message
 from .._remove_detached_files_and_jobs import _remove_detached_files_and_jobs
 from ...core.settings import get_settings
-
-class CreateJobRequestInputFile(BaseModel):
-    name: str
-    fileName: str
-
-class CreateJobRequestOutputFile(BaseModel):
-    name: str
-    fileName: str
-
-class CreateJobRequestInputParameter(BaseModel):
-    name: str
-    value: Union[Any, None]
+from ....common.dendro_types import CreateJobRequestInputFile, CreateJobRequestOutputFile, CreateJobRequestInputParameter
 
 class CreateJobException(Exception):
     pass

--- a/python/dendro/client/Project.py
+++ b/python/dendro/client/Project.py
@@ -14,7 +14,7 @@ class Project:
         project_data: DendroProject,
         files_data: List[DendroFile],
         jobs_data: List[DendroJob],
-        compute_resource: DendroComputeResource
+        compute_resource: Union[DendroComputeResource, None]
     ) -> None:
         self._project_id = project_data.projectId
         self._name = project_data.name
@@ -133,9 +133,12 @@ def load_project(project_id: str) -> Project:
     jobs_resp = _client_get_api_request(url_path=url_path)
     jobs: List[DendroJob] = [DendroJob(**j) for j in jobs_resp['jobs']]
 
-    url_path = f'/api/client/compute-resources/{project.computeResourceId}'
-    compute_resource_resp = _client_get_api_request(url_path=url_path)
-    compute_resource = DendroComputeResource(**compute_resource_resp['compute_resource'])
+    if project.computeResourceId:
+        url_path = f'/api/client/compute_resources/{project.computeResourceId}'
+        compute_resource_resp = _client_get_api_request(url_path=url_path)
+        compute_resource = DendroComputeResource(**compute_resource_resp['computeResource'])
+    else:
+        compute_resource = None
 
     return Project(project_data=project, files_data=files, jobs_data=jobs, compute_resource=compute_resource)
 

--- a/python/dendro/client/__init__.py
+++ b/python/dendro/client/__init__.py
@@ -1,1 +1,2 @@
 from .Project import Project, load_project # noqa: F401
+from .submit_job import submit_job # noqa: F401

--- a/python/dendro/client/__init__.py
+++ b/python/dendro/client/__init__.py
@@ -1,2 +1,2 @@
 from .Project import Project, load_project # noqa: F401
-from .submit_job import submit_job # noqa: F401
+from .submit_job import submit_job, SubmitJobInputFile, SubmitJobOutputFile, SubmitJobParameter # noqa: F401

--- a/python/dendro/client/_interim/NwbSorting.py
+++ b/python/dendro/client/_interim/NwbSorting.py
@@ -31,10 +31,10 @@ def _numpy_sorting_from_dict(units_dict_list, *, sampling_frequency):
         # different versions of spikeinterface
         # see: https://github.com/SpikeInterface/spikeinterface/issues/2083
         sorting = si.NumpySorting.from_dict( # type: ignore
-            units_dict_list, sampling_frequency=sampling_frequency
+            units_dict_list, sampling_frequency=sampling_frequency # type: ignore
         )
     except: # noqa
         sorting = si.NumpySorting.from_unit_dict( # type: ignore
-            units_dict_list, sampling_frequency=sampling_frequency
+            units_dict_list, sampling_frequency=sampling_frequency # type: ignore
         )
     return sorting

--- a/python/dendro/client/submit_job.py
+++ b/python/dendro/client/submit_job.py
@@ -1,0 +1,233 @@
+from typing import Any, List, Union
+import os
+from pydantic import BaseModel
+from .Project import Project
+from ..common.dendro_types import CreateJobRequest, CreateJobResponse, CreateJobRequestInputFile, CreateJobRequestOutputFile, CreateJobRequestInputParameter, ComputeResourceSpecProcessor, DendroJob
+from ..common._api_request import _client_post_api_request
+
+
+class SubmitJobInputFile(BaseModel):
+    name: str
+    file_name: str
+
+class SubmitJobOutputFile(BaseModel):
+    name: str
+    file_name: str
+
+class SubmitJobInputParameter(BaseModel):
+    name: str
+    value: Any
+
+def submit_job(*,
+    project: Project,
+    processor_name: str,
+    input_files: List[SubmitJobInputFile],
+    output_files: List[SubmitJobOutputFile],
+    input_parameters: List[SubmitJobInputParameter],
+    batch_id: Union[str, None] = None,
+    rerun_policy: str = 'never' # always | never | if_failed
+):
+    """Submit a job to the Dendro compute service.
+
+    Args:
+        project (Project): The project to submit the job to.
+        processor_name (str): The name of the processor to use.
+        input_files (List[SubmitJobInputFile]): The input files for the job.
+        output_files (List[SubmitJobOutputFile]): The output files for the job.
+        input_parameters (List[SubmitJobInputParameter]): The input parameters for the job.
+        batch_id (Union[str, None], optional): The batch ID to use. Defaults to None.
+        rerun_policy (str, optional): The rerun policy to use. One of: 'always', 'never', 'if_failed'. Defaults to 'never'.
+
+    Returns:
+        str: The job ID.
+    """
+    if rerun_policy not in ['always', 'never', 'if_failed']:
+        raise ValueError(f'Invalid rerun policy: {rerun_policy}')
+    compute_resource = project._compute_resource
+    processor_spec = None
+    if compute_resource.spec is None:
+        raise KeyError(f'No spec found for compute resource {compute_resource.name} for project {project._name} ({project._project_id})')
+    for app in compute_resource.spec.apps:
+        for processor in app.processors:
+            if processor.name == processor_name:
+                processor_spec = processor
+                break
+        if processor_spec:
+            break
+    if not processor_spec:
+        raise KeyError(f'No processor with name {processor_name} found in compute resource {compute_resource.name} for project {project._name} ({project._project_id})')
+    default_parameters = _create_default_parameters(processor_spec, input_parameters)
+    input_parameters = input_parameters + default_parameters
+    _check_consistency_with_processor_spec(
+        processor_spec=processor_spec,
+        processor_name=processor_name,
+        input_files=input_files,
+        output_files=output_files,
+        input_parameters=input_parameters
+    )
+    request_input_files = [
+        CreateJobRequestInputFile(
+            name=x.name,
+            fileName=x.file_name
+        )
+        for x in input_files
+    ]
+    request_output_files = [
+        CreateJobRequestOutputFile(
+            name=x.name,
+            fileName=x.file_name
+        )
+        for x in output_files
+    ]
+    request_input_parameters = [
+        CreateJobRequestInputParameter(
+            name=x.name,
+            value=x.value
+        )
+        for x in input_parameters
+    ]
+    matching_job = None
+    for job in project._jobs:
+        if _job_matches(
+            job=job,
+            processor_name=processor_name,
+            input_files=input_files,
+            output_files=output_files,
+            input_parameters=input_parameters
+        ):
+            matching_job = job
+            break
+    if matching_job:
+        rerun = True
+        if rerun_policy == 'never':
+            rerun = False
+        elif rerun_policy == 'if_failed':
+            if matching_job.status == 'failed':
+                rerun = True
+            else:
+                rerun = False
+        elif rerun_policy == 'always':
+            rerun = True
+        else:
+            raise ValueError(f'Invalid rerun policy: {rerun_policy}')
+        if not rerun:
+            return matching_job.jobId
+    req = CreateJobRequest(
+        projectId=project._project_id,
+        processorName=processor_name,
+        inputFiles=request_input_files,
+        outputFiles=request_output_files,
+        inputParameters=request_input_parameters,
+        processorSpec=processor_spec,
+        batchId=batch_id,
+        dandiApiKey=os.environ.get('DANDI_API_KEY', None)
+    )
+    resp = _client_post_api_request(
+        url_path='/jobs',
+        data=_model_dump(req)
+    )
+    resp = CreateJobResponse(**resp)
+    return resp.jobId
+
+def _create_default_parameters(
+    processor_spec: ComputeResourceSpecProcessor,
+    input_parameters: List[SubmitJobInputParameter]
+) -> List[SubmitJobInputParameter]:
+    default_parameters = []
+    for pp in processor_spec.parameters:
+        if not any(x.name == pp.name for x in input_parameters):
+            # need to wait for the model to be updated to include the "required" flag to do this
+            # if pp.required:
+            #     raise KeyError(f"Required parameter not found: {pp.name}")
+            default_parameters.append(SubmitJobInputParameter(name=pp.name, value=pp.default))
+    return default_parameters
+
+def _check_consistency_with_processor_spec(
+    processor_spec: ComputeResourceSpecProcessor,
+    processor_name: str,
+    input_files: List[SubmitJobInputFile],
+    output_files: List[SubmitJobOutputFile],
+    input_parameters: List[SubmitJobInputParameter]
+):
+    # check that the processor name matches
+    if processor_spec.name != processor_name:
+        raise KeyError(f'Processor name mismatch: {processor_spec.name} != {processor_name}')
+    # check that the input files are consistent with the spec
+    for input_file in input_files:
+        pp = next((x for x in processor_spec.inputs if x.name == input_file.name), None)
+        if not pp:
+            raise KeyError(f"Processor input not found: {input_file.name}")
+    # check that no input files are missing
+    for input in processor_spec.inputs:
+        if not any(x.name == input.name for x in input_files):
+            raise KeyError(f"Required input not found: {input.name}")
+    # check that the output files are consistent with the spec
+    for output_file in output_files:
+        pp = next((x for x in processor_spec.outputs if x.name == output_file.name), None)
+        if not pp:
+            raise KeyError(f"Processor output not found: {output_file.name}")
+    # check that no output files are missing
+    for output in processor_spec.outputs:
+        if not any(x.name == output.name for x in output_files):
+            raise KeyError(f"Required output not found: {output.name}")
+    # check that the input parameters are consistent with the spec
+    for input_parameter in input_parameters:
+        pp = next((x for x in processor_spec.parameters if x.name == input_parameter.name), None)
+        if not pp:
+            raise KeyError(f"Processor parameter not found: {input_parameter.name}")
+
+    # For this we need to wait for the model to be updated to include the "required" flag
+    # # check that no required parameters are missing
+    # for pp in processor_spec.parameters:
+    #     if pp.required:
+    #         input_parameter = next((x for x in input_parameters if x.name == pp.name), None)
+    #         if not input_parameter:
+    #             raise KeyError(f"Required parameter not found: {pp.name}")
+
+def _model_dump(model, exclude_none=False):
+    # handle both pydantic v1 and v2
+    if hasattr(model, 'model_dump'):
+        return model.model_dump(exclude_none=exclude_none)
+    else:
+        return model.dict(exclude_none=exclude_none)
+
+def _job_matches(*,
+    job: DendroJob,
+    processor_name: str,
+    input_files: List[SubmitJobInputFile],
+    output_files: List[SubmitJobOutputFile],
+    input_parameters: List[SubmitJobInputParameter]
+):
+    if job.processorName != processor_name:
+        return False
+
+    # input files
+    if len(job.inputFiles) != len(input_files):
+        return False
+    for input_file in input_files:
+        x = next((x for x in job.inputFiles if x.name == input_file.name), None)
+        if not x:
+            return False
+        if x.fileName != input_file.file_name:
+            return False
+
+    # output files
+    if len(job.outputFiles) != len(output_files):
+        return False
+    for output_file in output_files:
+        x = next((x for x in job.outputFiles if x.name == output_file.name), None)
+        if not x:
+            return False
+        if x.fileName != output_file.file_name:
+            return False
+
+    # input parameters
+    if len(job.inputParameters) != len(input_parameters):
+        return False
+    for input_parameter in input_parameters:
+        x = next((x for x in job.inputParameters if x.name == input_parameter.name), None)
+        if not x:
+            return False
+        if x.value != input_parameter.value:
+            return False
+    return True

--- a/python/dendro/common/_api_request.py
+++ b/python/dendro/common/_api_request.py
@@ -170,6 +170,26 @@ def _client_get_api_request(*,
         raise
     return resp.json()
 
+def _client_post_api_request(*,
+    url_path: str,
+    data: dict
+):
+    test_client = _globals['test_client']
+    if test_client is None:
+        url = f'{dendro_url}{url_path}'
+        client = requests
+    else:
+        assert url_path.startswith('/api')
+        url = url_path
+        client = test_client
+    try:
+        resp = client.post(url, json=data, timeout=60)
+        resp.raise_for_status()
+    except Exception as e:
+        print(f'Error in client post api request for {url}; {e}')
+        raise
+    return resp.json()
+
 ####################################################################################################
 # The GUI API requests below are only here for use with pytest since the real GUI requests come from the browser using typescript
 

--- a/python/dendro/common/_api_request.py
+++ b/python/dendro/common/_api_request.py
@@ -172,8 +172,12 @@ def _client_get_api_request(*,
 
 def _client_post_api_request(*,
     url_path: str,
-    data: dict
+    data: dict,
+    dendro_api_key: str
 ):
+    headers = {
+        'dendro-api-key': dendro_api_key
+    }
     test_client = _globals['test_client']
     if test_client is None:
         url = f'{dendro_url}{url_path}'
@@ -183,7 +187,7 @@ def _client_post_api_request(*,
         url = url_path
         client = test_client
     try:
-        resp = client.post(url, json=data, timeout=60)
+        resp = client.post(url, headers=headers, json=data, timeout=60)
         resp.raise_for_status()
     except Exception as e:
         print(f'Error in client post api request for {url}; {e}')

--- a/python/dendro/common/dendro_types.py
+++ b/python/dendro/common/dendro_types.py
@@ -162,3 +162,7 @@ class ProcessorGetJobResponse(BaseModel):
     inputs: List[ProcessorGetJobResponseInput]
     outputs: List[ProcessorGetJobResponseOutput]
     parameters: List[ProcessorGetJobResponseParameter]
+
+class DendroUser(BaseModel):
+    userId: str
+    dendroApiKey: Union[str, None] = None

--- a/python/dendro/common/dendro_types.py
+++ b/python/dendro/common/dendro_types.py
@@ -166,3 +166,29 @@ class ProcessorGetJobResponse(BaseModel):
 class DendroUser(BaseModel):
     userId: str
     dendroApiKey: Union[str, None] = None
+
+class CreateJobRequestInputFile(BaseModel):
+    name: str
+    fileName: str
+
+class CreateJobRequestOutputFile(BaseModel):
+    name: str
+    fileName: str
+
+class CreateJobRequestInputParameter(BaseModel):
+    name: str
+    value: Union[Any, None]
+
+class CreateJobRequest(BaseModel):
+    projectId: str
+    processorName: str
+    inputFiles: List[CreateJobRequestInputFile]
+    outputFiles: List[CreateJobRequestOutputFile]
+    inputParameters: List[CreateJobRequestInputParameter]
+    processorSpec: ComputeResourceSpecProcessor
+    batchId: Union[str, None] = None
+    dandiApiKey: Union[str, None] = None
+
+class CreateJobResponse(BaseModel):
+    jobId: str
+    success: bool

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -10,9 +10,9 @@ import json
 @pytest.mark.api
 async def test_integration(tmp_path):
     # important to put the imports inside so we don't get an import error when running the non-api tests
-    from dendro.common.dendro_types import DendroProjectUser, DendroComputeResourceApp
+    from dendro.common.dendro_types import DendroProjectUser, DendroComputeResourceApp, CreateJobRequestInputParameter, CreateJobRequestInputFile, CreateJobRequestOutputFile
     from dendro.api_helpers.routers.gui._authenticate_gui_request import _create_mock_github_access_token
-    from dendro.api_helpers.routers.gui.create_job_route import CreateJobRequest, CreateJobResponse, CreateJobRequestInputParameter, CreateJobRequestInputFile, CreateJobRequestOutputFile
+    from dendro.api_helpers.routers.gui.create_job_route import CreateJobRequest, CreateJobResponse
     from dendro.compute_resource.register_compute_resource import register_compute_resource
     from dendro.compute_resource.start_compute_resource import start_compute_resource
     from dendro.common._api_request import _use_api_test_client

--- a/src/ApplicationBar.tsx
+++ b/src/ApplicationBar.tsx
@@ -103,7 +103,7 @@ const ApplicationBar: FunctionComponent<Props> = () => {
             </ModalWindow>
             <ModalWindow
                 open={apiKeysWindowVisible}
-                // onClose={closeApiKeysWindow}
+                onClose={closeApiKeysWindow}
             >
                 <ApiKeysWindow
                     onClose={() => closeApiKeysWindow()}

--- a/src/dbInterface/dbInterface.ts
+++ b/src/dbInterface/dbInterface.ts
@@ -470,6 +470,14 @@ export const getComputeResource = async (computeResourceId: string): Promise<any
     return response.computeResource
 }
 
+export const createDendroApiKeyForUser = async (auth: Auth): Promise<string> => {
+    if (!auth.userId) throw Error('No userId')
+    const url = `${apiBase}/api/gui/users/${auth.userId}/dendro_api_key`
+    const response = await postRequest(url, {}, auth)
+    if (!response.success) throw Error(`Error in createDendroApiKeyForUser: ${response.error}`)
+    return response.dendroApiKey
+}
+
 const deepEqual = (a: any, b: any): boolean => {
     if (typeof a !== typeof b) {
         return false


### PR DESCRIPTION
@luiztauffer 

Here I provide a way for the user to generate a Dendro API key associated with their user ID. The idea is to give access to a subset of the API to a non-browser client. I particularly want to allow queuing jobs from a Python script for an existing project. Prior to this, the create job endpoint required a github token which is really for use within a browser.