### PR TITLE
Job required resources

### DIFF
--- a/python/dendro/api_helpers/routers/gui/create_job_route.py
+++ b/python/dendro/api_helpers/routers/gui/create_job_route.py
@@ -36,6 +36,7 @@ async def create_job_handler(
     processor_spec = data.processorSpec
     batch_id = data.batchId
     dandi_api_key = data.dandiApiKey
+    required_resources = data.requiredResources
 
     job_id = await create_job(
         project_id=project_id,
@@ -46,7 +47,8 @@ async def create_job_handler(
         processor_spec=processor_spec,
         batch_id=batch_id,
         user_id=user_id,
-        dandi_api_key=dandi_api_key
+        dandi_api_key=dandi_api_key,
+        required_resources=required_resources
     )
 
     return CreateJobResponse(

--- a/python/dendro/client/submit_job.py
+++ b/python/dendro/client/submit_job.py
@@ -2,7 +2,7 @@ from typing import Any, List, Union
 import os
 from pydantic import BaseModel
 from .Project import Project
-from ..common.dendro_types import CreateJobRequest, CreateJobResponse, CreateJobRequestInputFile, CreateJobRequestOutputFile, CreateJobRequestInputParameter, ComputeResourceSpecProcessor, DendroJob
+from ..common.dendro_types import CreateJobRequest, CreateJobResponse, CreateJobRequestInputFile, CreateJobRequestOutputFile, CreateJobRequestInputParameter, ComputeResourceSpecProcessor, DendroJob, DendroJobRequiredResources
 from ..common._api_request import _client_post_api_request
 
 
@@ -25,7 +25,8 @@ def submit_job(*,
     output_files: List[SubmitJobOutputFile],
     parameters: List[SubmitJobParameter],
     batch_id: Union[str, None] = None,
-    rerun_policy: str = 'never' # always | never | if_failed
+    rerun_policy: str = 'never', # always | never | if_failed
+    required_resources: DendroJobRequiredResources
 ):
     """Submit a job to the Dendro compute service.
 
@@ -123,7 +124,8 @@ def submit_job(*,
         inputParameters=request_parameters,
         processorSpec=processor_spec,
         batchId=batch_id,
-        dandiApiKey=os.environ.get('DANDI_API_KEY', None)
+        dandiApiKey=os.environ.get('DANDI_API_KEY', None),
+        requiredResources=required_resources
     )
 
     dendro_api_key = os.environ.get('DENDRO_API_KEY', None)

--- a/python/dendro/common/dendro_types.py
+++ b/python/dendro/common/dendro_types.py
@@ -66,6 +66,18 @@ class ComputeResourceSpecProcessor(BaseModel):
     attributes: List[ComputeResourceSpecProcessorAttribute]
     tags: List[ComputeResourceSpecProcessorTag]
 
+class DendroJobRequiredResources(BaseModel):
+    numCpus: int
+    numGpus: int
+    memoryGb: float
+    timeSec: float
+
+class DendroJobUsedResources(BaseModel):
+    numCpus: int
+    numGpus: int
+    memoryGb: float
+    timeSec: float
+
 class DendroJob(BaseModel):
     projectId: str
     jobId: str
@@ -76,6 +88,8 @@ class DendroJob(BaseModel):
     inputFileIds: List[str]
     inputParameters: List[DendroJobInputParameter]
     outputFiles: List[DendroJobOutputFile]
+    requiredResources: Union[DendroJobRequiredResources, None] = None
+    usedResources: Union[DendroJobUsedResources, None] = None
     timestampCreated: float
     computeResourceId: str
     status: str # 'pending' | 'queued' | 'starting' | 'running' | 'completed' | 'failed'
@@ -193,6 +207,7 @@ class CreateJobRequest(BaseModel):
     processorSpec: ComputeResourceSpecProcessor
     batchId: Union[str, None] = None
     dandiApiKey: Union[str, None] = None
+    requiredResources: DendroJobRequiredResources
 
 class CreateJobResponse(BaseModel):
     jobId: str

--- a/python/dendro/compute_resource/JobManager.py
+++ b/python/dendro/compute_resource/JobManager.py
@@ -97,13 +97,16 @@ class JobManager:
         try:
             print(f'Starting job {job_id} {processor_name}')
             from ._start_job import _start_job
+            if job.requiredResources is None:
+                raise Exception('Cannot start job... requiredResources is None')
             return _start_job(
                 job_id=job_id,
                 job_private_key=job_private_key,
                 processor_name=processor_name,
                 app=app,
                 run_process=run_process,
-                return_shell_command=return_shell_command
+                return_shell_command=return_shell_command,
+                required_resources=job.requiredResources
             )
         except Exception as e: # pylint: disable=broad-except
             # do a traceback

--- a/python/dendro/compute_resource/_start_job.py
+++ b/python/dendro/compute_resource/_start_job.py
@@ -4,7 +4,7 @@ import subprocess
 from typing import Union, Dict, Any
 from ..sdk.App import App
 from ..common._api_request import _processor_put_api_request
-from ..common.dendro_types import ComputeResourceSlurmOpts
+from ..common.dendro_types import ComputeResourceSlurmOpts, DendroJobRequiredResources
 from ._run_job_in_aws_batch import _run_job_in_aws_batch
 from ..mock import using_mock
 
@@ -39,7 +39,8 @@ def _start_job(*,
     processor_name: str,
     app: App,
     run_process: bool = True,
-    return_shell_command: bool = False
+    return_shell_command: bool = False,
+    required_resources: DendroJobRequiredResources
 ):
     assert not (return_shell_command and run_process), 'Cannot set both run_process and return_shell_command to True'
     assert return_shell_command or run_process, 'Cannot set both run_process and return_shell_command to False'
@@ -73,7 +74,8 @@ def _start_job(*,
                 app_name=app._name,
                 requires_gpu=app._requires_gpu,
                 container=app_image, # for verifying consistent with job definition
-                command=app_executable
+                command=app_executable,
+                required_resources=required_resources
             )
         except Exception as e:
             raise JobException(f'Error running job in AWS Batch: {e}') from e

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -20,6 +20,7 @@ async def test_integration(tmp_path):
     from dendro.api_helpers.clients._get_mongo_client import _clear_mock_mongo_databases
     from dendro.common._api_request import _gui_post_api_request, _client_get_api_request
     from dendro.common.dendro_types import ComputeResourceSlurmOpts
+    from dendro.common.dendro_types import DendroJobRequiredResources
 
     tmpdir = str(tmp_path)
 
@@ -249,6 +250,7 @@ async def test_integration(tmp_path):
                 processorSpec=processor_spec,
                 batchId=None,
                 dandiApiKey=None,
+                requiredResources=DendroJobRequiredResources(numCpus=1, numGpus=0, memoryGb=8, timeSec=3600)
             )
             resp = _gui_post_api_request(url_path='/api/gui/jobs', data=_model_dump(req), github_access_token=github_access_token)
             resp = CreateJobResponse(**resp)
@@ -276,6 +278,7 @@ async def test_integration(tmp_path):
             processorSpec=processor_spec_2,
             batchId=None,
             dandiApiKey=None,
+            requiredResources=DendroJobRequiredResources(numCpus=1, numGpus=0, memoryGb=8, timeSec=3600)
         )
         resp = _gui_post_api_request(url_path='/api/gui/jobs', data=_model_dump(req), github_access_token=github_access_token)
         resp = CreateJobResponse(**resp)
@@ -296,6 +299,7 @@ async def test_integration(tmp_path):
             processorSpec=processor_spec_2,
             batchId=None,
             dandiApiKey=None,
+            requiredResources=DendroJobRequiredResources(numCpus=1, numGpus=0, memoryGb=8, timeSec=3600)
         )
         with pytest.raises(Exception):
             _gui_post_api_request(url_path='/api/gui/jobs', data=_model_dump(req), github_access_token=github_access_token)

--- a/src/dbInterface/dbInterface.ts
+++ b/src/dbInterface/dbInterface.ts
@@ -1,5 +1,5 @@
 import { GithubAuthData } from "../GithubAuth/GithubAuthContext";
-import { ComputeResourceAwsBatchOpts, ComputeResourceSlurmOpts, ComputeResourceSpecProcessor, DendroComputeResource, DendroFile, DendroJob, DendroProject, isDendroFile, isDendroJob, isDendroProject } from "../types/dendro-types";
+import { ComputeResourceAwsBatchOpts, ComputeResourceSlurmOpts, ComputeResourceSpecProcessor, DendroComputeResource, DendroFile, DendroJob, DendroJobRequiredResources, DendroProject, isDendroFile, isDendroJob, isDendroProject } from "../types/dendro-types";
 import getAuthorizationHeaderForUrl from "./getAuthorizationHeaderForUrl";
 
 type Auth = GithubAuthData
@@ -386,11 +386,12 @@ export const createJob = async (
         jobDefinition: DendroProcessingJobDefinition,
         processorSpec: ComputeResourceSpecProcessor,
         files: DendroFile[],
-        batchId?: string
+        batchId?: string,
+        requiredResources: DendroJobRequiredResources
     },
     auth: Auth
 ) : Promise<string> => {
-    const {projectId, jobDefinition, processorSpec, files, batchId} = a
+    const {projectId, jobDefinition, processorSpec, files, batchId, requiredResources} = a
     const processorName = jobDefinition.processorName
     const inputFiles = jobDefinition.inputFiles
     const inputParameters = jobDefinition.inputParameters
@@ -426,7 +427,8 @@ export const createJob = async (
         inputParameters,
         outputFiles,
         processorSpec,
-        batchId
+        batchId,
+        requiredResources
     }
     if (dandiApiKey) {
         body.dandiApiKey = dandiApiKey

--- a/src/pages/ProjectPage/DandiUpload/DandiUploadWindow.tsx
+++ b/src/pages/ProjectPage/DandiUpload/DandiUploadWindow.tsx
@@ -3,7 +3,7 @@ import { useGithubAuth } from "../../../GithubAuth/useGithubAuth";
 import { DendroProcessingJobDefinition, createJob } from "../../../dbInterface/dbInterface";
 import { useProject } from "../ProjectPageContext";
 import { DandiUploadTask } from "./prepareDandiUploadTask";
-import { DendroFile, DendroJob } from "../../../types/dendro-types";
+import { DendroFile, DendroJob, DendroJobRequiredResources } from "../../../types/dendro-types";
 
 type DandiUploadWindowProps = {
     dandiUploadTask: DandiUploadTask
@@ -78,12 +78,19 @@ const DandiUploadWindow: FunctionComponent<DandiUploadWindowProps> = ({ dandiUpl
             ],
             outputFiles: []
         }
+        const requiredResources: DendroJobRequiredResources = {
+            numCpus: 2,
+            numGpus: 0,
+            memoryGb: 8,
+            timeSec: 3600 * 1
+        }
         const job = {
             projectId,
             jobDefinition: jobDef,
             processorSpec: processor,
             files,
-            batchId: undefined
+            batchId: undefined,
+            requiredResources
         }
         console.log('CREATING JOB', job)
         await createJob(job, auth)

--- a/src/pages/ProjectPage/FileEditor/SpikeSortingOutputSection/SpikeSortingOutputSection.tsx
+++ b/src/pages/ProjectPage/FileEditor/SpikeSortingOutputSection/SpikeSortingOutputSection.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useCallback, useMemo } from "react";
 import Hyperlink from "../../../../components/Hyperlink";
 import { createJob, DendroProcessingJobDefinition } from "../../../../dbInterface/dbInterface";
 import { useGithubAuth } from "../../../../GithubAuth/useGithubAuth";
-import { DendroJob } from "../../../../types/dendro-types";
+import { DendroJob, DendroJobRequiredResources } from "../../../../types/dendro-types";
 import { useProject } from "../../ProjectPageContext";
 import { isElectricalSeriesPathParameter } from "../../EditJobDefinitionWindow/EditJobDefinitionWindow";
 import { useModalDialog } from "../../../../ApplicationBar";
@@ -106,12 +106,19 @@ const SpikeSortingOutputSection: FunctionComponent<SpikeSortingOutputSectionProp
                 }
             ]
         }
+        const requiredResources: DendroJobRequiredResources = {
+            numCpus: 4,
+            numGpus: 0,
+            memoryGb: 8,
+            timeSec: 3600
+        }
         await createJob({
             projectId,
             jobDefinition,
             processorSpec: spikeSortingFigurlProcessor,
             files,
-            batchId: undefined
+            batchId: undefined,
+            requiredResources
         }, auth)
     }, [spikeSortingFigurlProcessor, projectId, recordingFileName, auth, fileName, electricalSeriesPath, files])
 

--- a/src/types/dendro-types.ts
+++ b/src/types/dendro-types.ts
@@ -172,6 +172,38 @@ export const isComputeResourceSpecProcessor = (x: any): x is ComputeResourceSpec
     }, {callback: (e) => {console.warn(e);}})
 }
 
+export type DendroJobRequiredResources = {
+    numCpus: number
+    numGpus: number
+    memoryGb: number
+    timeSec: number
+}
+
+export const isDendroJobRequiredResources = (x: any): x is DendroJobRequiredResources => {
+    return validateObject(x, {
+        numCpus: isNumber,
+        numGpus: isNumber,
+        memoryGb: isNumber,
+        timeSec: isNumber
+    })
+}
+
+export type DendroJobUsedResources = {
+    numCpus: number
+    numGpus: number
+    memoryGb: number
+    timeSec: number
+}
+
+export const isDendroJobUsedResources = (x: any): x is DendroJobUsedResources => {
+    return validateObject(x, {
+        numCpus: isNumber,
+        numGpus: isNumber,
+        memoryGb: isNumber,
+        timeSec: isNumber
+    })
+}
+
 export type DendroJob = {
     projectId: string
     jobId: string
@@ -183,6 +215,8 @@ export type DendroJob = {
     inputFileIds: string[]
     inputParameters: DendroJobInputParameter[]
     outputFiles: DendroJobOutputFile[]
+    requiredResources?: DendroJobRequiredResources
+    usedResources?: DendroJobUsedResources
     timestampCreated: number
     computeResourceId: string
     status: 'pending' | 'queued' | 'starting' | 'running' | 'completed' | 'failed'
@@ -214,6 +248,8 @@ export const isDendroJob = (x: any): x is DendroJob => {
         inputFileIds: isArrayOf(isString),
         inputParameters: isArrayOf(isDendroJobInputParameter),
         outputFiles: isArrayOf(isDendroJobOutputFile),
+        requiredResources: optional(isDendroJobRequiredResources),
+        usedResources: optional(isDendroJobUsedResources),
         timestampCreated: isNumber,
         computeResourceId: isString,
         status: isOneOf([isEqualTo('pending'), isEqualTo('queued'), isEqualTo('starting'), isEqualTo('running'), isEqualTo('completed'), isEqualTo('failed')]),


### PR DESCRIPTION
At the time of job creation, a requiredResources parameter is set with

numCpus, numGpus, memoryGb, timeSec

For now these are hard-coded on the frontend based on the tags of the processor. Tags respected are: kilosort2_5, kilosort3, mountainsort5

For non-spike sorting processors, the requiredResources are also hard-coded.

These parameters impact AWS job submission.