### PR TITLE
reorganize run method for jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 slurm_batch_*
+slurm_group_assignments
 tmp
 __pycache__
 

--- a/doc/host_compute_resource.md
+++ b/doc/host_compute_resource.md
@@ -50,31 +50,3 @@ The following are available apps that you can configure
 | kilosort2_5 | https://github.com/scratchrealm/pc-spike-sorting/blob/main/kilosort2_5/spec.json |
 | spike-sorting_utils | https://github.com/scratchrealm/pc-spike-sorting/blob/main/spike_sorting_utils/spec.json |
 | dandi-upload | https://github.com/scratchrealm/pc-spike-sorting/blob/main/dandi_upload/spec.json |
-
-## Configuring apps to use a Slurm cluster
-
-If you have access to a Slurm cluster, you can configure apps to use it. This is done by providing the following fields when configuring the app in the web interface
-
-* CPUs per task: e.g., `4`
-* Partition: the name of the Slurm partition to use
-* Time: the maximum time to allow for a single job (impacts job scheduling) (e.g., `5:00:00` for 5 hours)
-* Other options: any other options to pass to the `srun` command (e.g., `--gpus=1`)
-
-Don't forget to reload the page after making changes to the web interface.
-
-## Configuring apps to use AWS Batch
-
-To use AWS Batch, you will need to set up an AWS Batch compute environment and job queue. You will also need to set up an AWS Batch job definition for each app you want to use. The job definition should be configured to use the appropriate docker image for the app. If you are a beta tester, you can reach out to the authors for help configuring this.
-
-You will need to provide the following fields when configuring the app in the web interface.
-
-* Job queue: the name of the AWS Batch job queue to use
-* Job definition: the name of the AWS Batch job definition to use
-
-You will also need to provide your AWS credentials in the `.dendro-compute-resource-node.yaml` in the directory where your compute resource node daemon is running.
-
-Don't forget to reload the page after making changes to the web interface.
-
-## Configuring apps to use a local machine
-
-By default, if you do not configure your app to use AWS Batch or a Slurm cluster, it will use your local machine to run jobs, or the machine where the compute resource node daemon is running.

--- a/doc/iaac_aws_batch.md
+++ b/doc/iaac_aws_batch.md
@@ -1,6 +1,6 @@
 # AWS Batch IaaC
 
-In order to run Dendro Apps as AWS Batch jobs, the infrastructure must be provisioned first. This is done in two stages:
+In order to run Dendro jobs in AWS Batch, the infrastructure must be provisioned first. This is done in two stages:
 
 1. Before installing any Apps: Provision the base AWS Batch infrastructure using CDK. This includes IAM roles, VPC, Security Group, EFS filesystems, Batch Compute Environments and Batch Job Queues.
 2. At every App install: Provision the App-specific infrastructure using Boto3. This includes one EFS Volume one Batch Job Definition.

--- a/python/dendro/api_helpers/routers/gui/create_job_route.py
+++ b/python/dendro/api_helpers/routers/gui/create_job_route.py
@@ -37,6 +37,7 @@ async def create_job_handler(
     batch_id = data.batchId
     dandi_api_key = data.dandiApiKey
     required_resources = data.requiredResources
+    run_method = data.runMethod
 
     job_id = await create_job(
         project_id=project_id,
@@ -48,7 +49,8 @@ async def create_job_handler(
         batch_id=batch_id,
         user_id=user_id,
         dandi_api_key=dandi_api_key,
-        required_resources=required_resources
+        required_resources=required_resources,
+        run_method=run_method
     )
 
     return CreateJobResponse(

--- a/python/dendro/api_helpers/services/gui/create_job.py
+++ b/python/dendro/api_helpers/services/gui/create_job.py
@@ -1,5 +1,6 @@
 import time
-from typing import Union, List, Any
+from typing import Union, List, Any, Literal
+
 from ....common.dendro_types import ComputeResourceSpecProcessor, DendroJobInputFile, DendroJobOutputFile, DendroJob, DendroJobInputParameter, DendroJobRequiredResources
 from ...clients.db import fetch_project, fetch_file, delete_file, fetch_project_jobs, delete_job, insert_job
 from ...core._get_project_role import _check_user_can_edit_project
@@ -22,7 +23,8 @@ async def create_job(*,
     batch_id: Union[str, None],
     user_id: str,
     dandi_api_key: Union[str, None] = None,
-    required_resources: DendroJobRequiredResources
+    required_resources: DendroJobRequiredResources,
+    run_method: Literal['local', 'aws_batch', 'slurm']
 ):
     _check_job_is_consistent_with_processor_spec(
         processor_spec=processor_spec,
@@ -129,7 +131,8 @@ async def create_job(*,
         dandiApiKey=dandi_api_key,
         consoleOutputUrl=f"{output_bucket_base_url}/dendro-outputs/{job_id}/_console_output",
         resourceUtilizationLogUrl=f"{output_bucket_base_url}/dendro-outputs/{job_id}/_resource_utilization_log",
-        requiredResources=required_resources
+        requiredResources=required_resources,
+        runMethod=run_method
     )
 
     await insert_job(job)

--- a/python/dendro/client/submit_job.py
+++ b/python/dendro/client/submit_job.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Union
+from typing import Any, List, Union, Literal
 import os
 from pydantic import BaseModel
 from .Project import Project
@@ -26,7 +26,8 @@ def submit_job(*,
     parameters: List[SubmitJobParameter],
     batch_id: Union[str, None] = None,
     rerun_policy: str = 'never', # always | never | if_failed
-    required_resources: DendroJobRequiredResources
+    required_resources: DendroJobRequiredResources,
+    run_method: Literal['local', 'aws_batch', 'slurm']
 ):
     """Submit a job to the Dendro compute service.
 
@@ -125,7 +126,8 @@ def submit_job(*,
         processorSpec=processor_spec,
         batchId=batch_id,
         dandiApiKey=os.environ.get('DANDI_API_KEY', None),
-        requiredResources=required_resources
+        requiredResources=required_resources,
+        runMethod=run_method
     )
 
     dendro_api_key = os.environ.get('DENDRO_API_KEY', None)

--- a/python/dendro/common/dendro_types.py
+++ b/python/dendro/common/dendro_types.py
@@ -151,6 +151,8 @@ class ComputeResourceSpecApp(BaseModel):
 
 class ComputeResourceSpec(BaseModel):
     apps: List[ComputeResourceSpecApp]
+    defaultJobRunMethod: Literal['local', 'aws_batch', 'slurm']
+    availableJobRunMethods: List[Literal['local', 'aws_batch', 'slurm']]
 
 class DendroComputeResource(BaseModel):
     computeResourceId: str

--- a/python/dendro/common/dendro_types.py
+++ b/python/dendro/common/dendro_types.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Any, Optional
+from typing import Union, List, Any, Optional, Literal
 
 from .. import BaseModel
 
@@ -90,6 +90,7 @@ class DendroJob(BaseModel):
     outputFiles: List[DendroJobOutputFile]
     requiredResources: Union[DendroJobRequiredResources, None] = None
     usedResources: Union[DendroJobUsedResources, None] = None
+    runMethod: Union[Literal['local', 'aws_batch', 'slurm'], None] = None
     timestampCreated: float
     computeResourceId: str
     status: str # 'pending' | 'queued' | 'starting' | 'running' | 'completed' | 'failed'
@@ -120,11 +121,13 @@ class DendroFile(BaseModel):
     metadata: dict
     jobId: Union[str, None] = None # the job that produced this file
 
+# obsolete
 class ComputeResourceAwsBatchOpts(BaseModel):
     jobQueue: Optional[str] = None # obsolete
     jobDefinition: Optional[str] = None # obsolete
-    useAwsBatch: Optional[bool] = None
+    useAwsBatch: Optional[bool] = None # obsolete
 
+# obsolete
 class ComputeResourceSlurmOpts(BaseModel):
     partition: Union[str, None] = None
     time: Union[str, None] = None
@@ -136,8 +139,8 @@ class DendroComputeResourceApp(BaseModel):
     specUri: str
     executablePath: Union[str, None] = None # to be removed (once database has been cleared)
     container: Union[str, None] = None # to be removed (once database has been cleared)
-    awsBatch: Union[ComputeResourceAwsBatchOpts, None] = None
-    slurm: Union[ComputeResourceSlurmOpts, None] = None
+    awsBatch: Union[ComputeResourceAwsBatchOpts, None] = None # obsolete
+    slurm: Union[ComputeResourceSlurmOpts, None] = None # obsolete
 
 class ComputeResourceSpecApp(BaseModel):
     name: str
@@ -207,6 +210,7 @@ class CreateJobRequest(BaseModel):
     batchId: Union[str, None] = None
     dandiApiKey: Union[str, None] = None
     requiredResources: DendroJobRequiredResources
+    runMethod: Literal['local', 'aws_batch', 'slurm']
 
 class CreateJobResponse(BaseModel):
     jobId: str

--- a/python/dendro/common/dendro_types.py
+++ b/python/dendro/common/dendro_types.py
@@ -151,8 +151,8 @@ class ComputeResourceSpecApp(BaseModel):
 
 class ComputeResourceSpec(BaseModel):
     apps: List[ComputeResourceSpecApp]
-    defaultJobRunMethod: Literal['local', 'aws_batch', 'slurm']
-    availableJobRunMethods: List[Literal['local', 'aws_batch', 'slurm']]
+    defaultJobRunMethod: Union[Literal['local', 'aws_batch', 'slurm'], None] = None
+    availableJobRunMethods: Union[List[Literal['local', 'aws_batch', 'slurm']], None] = None
 
 class DendroComputeResource(BaseModel):
     computeResourceId: str

--- a/python/dendro/compute_resource/AppManager.py
+++ b/python/dendro/compute_resource/AppManager.py
@@ -61,6 +61,8 @@ class AppManager:
             default_job_run_method = os.environ.get('DEFAULT_JOB_RUN_METHOD', 'local')
             available_job_run_methods_str = os.environ.get('AVAILABLE_JOB_RUN_METHODS', 'local')
             available_job_run_methods = [s.strip() for s in available_job_run_methods_str.split(',')]
+            print(f'  default_job_run_method: {default_job_run_method}')
+            print(f'  available_job_run_methods: {available_job_run_methods}')
             spec = {
                 'apps': [a._spec_dict for a in self._apps],
                 'defaultJobRunMethod': default_job_run_method,

--- a/python/dendro/compute_resource/JobManager.py
+++ b/python/dendro/compute_resource/JobManager.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 # TODO: make these configurable
 max_simultaneous_local_jobs = 2
 max_simultaneous_aws_batch_jobs = 20
-max_simultaneous_slurm_jobs = 50
 
 class JobManager:
     def __init__(self, *,

--- a/python/dendro/compute_resource/SlurmJobHandler.py
+++ b/python/dendro/compute_resource/SlurmJobHandler.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .JobManager import JobManager
 
 
-max_num_simultaneous_slurm_groups = 5 # TODO: make these configurable
+max_num_simultaneous_slurm_groups = 5 # TODO: make this configurable
 
 # This will determine how many cpu jobs get grouped together in a single slurm job
 num_cpus_per_slurm_node = 100 # TODO: make this configurable
@@ -131,7 +131,7 @@ class SlurmJobHandler:
             oo.append(f'--cpus-per-task={num_cpus_per_job}')
             oo.append(f'--partition={slurm_partition}')
             if num_gpus_per_job > 0:
-                oo.append(f'---gpus-per-task={num_gpus_per_job}')
+                oo.append(f'--gpus-per-task={num_gpus_per_job}')
             oo.append(f'--time={slurm_time}')
 
             # provide memory per cpu

--- a/python/dendro/compute_resource/SlurmJobHandler.py
+++ b/python/dendro/compute_resource/SlurmJobHandler.py
@@ -97,7 +97,6 @@ class SlurmJobHandler:
                         # this is how we make sure one and only one job is run in each process
                         f.write(f'if [ "$SLURM_PROCID" == "{ii}" ]; then\n')
                         f.write(f'    {cmd}\n')
-                        f.write(f'    rm slurm_group_assignments/{job.jobId}\n')
                         f.write('fi\n')
                         f.write('\n')
                     else:

--- a/python/dendro/compute_resource/SlurmJobHandler.py
+++ b/python/dendro/compute_resource/SlurmJobHandler.py
@@ -1,69 +1,114 @@
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 import os
 import time
 import subprocess
 
 from ..mock import using_mock
-from ..common.dendro_types import DendroJob
+from ..common.dendro_types import DendroJob, DendroJobRequiredResources
 
 if TYPE_CHECKING:
     from .JobManager import JobManager
 
 
+max_num_simultaneous_slurm_groups = 5 # TODO: make these configurable
+
+# This will determine how many cpu jobs get grouped together in a single slurm job
+num_cpus_per_slurm_node = 100 # TODO: make this configurable
+
 class SlurmJobHandler:
     def __init__(self, *, job_manager: 'JobManager'):
         self._job_manager = job_manager
+        self._last_time_we_got_a_new_job = 0
         self._jobs: List[DendroJob] = []
-        self._job_ids = set()
-        self._time_of_last_job_added = 0
-    def add_job(self, job: DendroJob):
-        job_id = job.jobId
-        if job_id not in self._job_ids:
-            self._jobs.append(job)
-            self._job_ids.add(job_id)
-            self._time_of_last_job_added = time.time()
+        self._job_ids_attempted_to_start_or_fail = set() # we don't want to attempt to start the same job multiple times
+        self._last_disk_cleanup_time = 0
+        # We don't want to store any state in memory!
+        # so if we restart the compute resource, we don't want that to interrupt the process of knowing when
+        # to start new job groups.
+    def handle_jobs(self, jobs: List[DendroJob]):
+        current_job_ids = set([job.jobId for job in self._jobs])
+        for job in jobs:
+            if job.jobId not in current_job_ids:
+                self._last_time_we_got_a_new_job = time.time()
+        self._jobs = jobs
     def do_work(self):
-        if len(self._jobs) == 0:
-            return
+        if time.time() > self._last_disk_cleanup_time + 300:
+            _clean_up_old_files()
+            self._last_disk_cleanup_time = time.time()
 
         time_scale_factor = 1 if not using_mock() else 10000
 
-        elapsed_since_last_job_added = time.time() - self._time_of_last_job_added
-        # wait a bit before starting jobs because maybe more will be added, and we want to start them all at once
-        if elapsed_since_last_job_added < 5 / time_scale_factor:
+        elapsed_since_got_new_job = time.time() - self._last_time_we_got_a_new_job
+        if elapsed_since_got_new_job < 5 / time_scale_factor:
+            # wait because we might still have jobs coming in and we need to start them in groups
             return
+        if len(self._jobs) == 0:
+            # we have no jobs
+            return
+        pending_jobs = [job for job in self._jobs if job.status == 'pending' and job.jobId not in self._job_ids_attempted_to_start_or_fail]
+        pending_job_groups = _split_jobs_into_groups(pending_jobs)
 
-        max_jobs_in_batch = 20
-        num_jobs_to_start = min(max_jobs_in_batch, len(self._jobs))
-        if num_jobs_to_start > 0:
-            jobs_to_start = self._jobs[:num_jobs_to_start]
-            self._jobs = self._jobs[num_jobs_to_start:]
-            for job in jobs_to_start:
-                self._job_ids.remove(job.jobId)
-            self._run_slurm_batch(jobs_to_start)
-    def _run_slurm_batch(self, jobs: List[DendroJob]):
+        num_running_groups = self._determine_num_running_groups()
+
+        for job_group in pending_job_groups:
+            if num_running_groups >= max_num_simultaneous_slurm_groups:
+                break
+            self._start_job_group(job_group)
+            num_running_groups += 1
+    def _start_job_group(self, job_group: 'PendingJobGroup'):
+        # a job group is a collection of jobs that should ideally fit in a single node on the cluster
+        jobs = job_group._jobs
+        required_resources = job_group._required_resources
+        for job in jobs:
+            self._job_ids_attempted_to_start_or_fail.add(job.jobId)
+
         if not os.path.exists('slurm_scripts'):
             os.mkdir('slurm_scripts')
+        if not os.path.exists('slurm_group_assignments'):
+            os.mkdir('slurm_group_assignments')
+
+        num_cpus_per_job = required_resources.numCpus
+        num_gpus_per_job = required_resources.numGpus
+        memory_gb_per_job = required_resources.memoryGb
+        timeout_sec_per_job = required_resources.timeSec
+
+        if num_gpus_per_job > 1:
+            self._fail_jobs(jobs, 'numGpus > 1 is not supported (SlurmBatchHandler)')
+            return
+
         random_str = os.urandom(16).hex()
-        slurm_script_fname = f'slurm_scripts/slurm_batch_{random_str}.sh'
-        script_has_at_least_one_job = False # important to do this so we don't run an empty script
+        timestamp = _create_nice_timestamp()
+
+        slurm_group_id = f'{timestamp}_{random_str}'
+        slurm_script_fname = f'slurm_scripts/slurm_batch_{slurm_group_id}.sh'
+        script_has_at_least_one_job = False # important to do this so we don't ever run an empty script
         with open(slurm_script_fname, 'w', encoding='utf8') as f:
             f.write('#!/bin/bash\n')
             f.write('\n')
             f.write('set -e\n')
             f.write('\n')
             for ii, job in enumerate(jobs):
+                # doesn't actually start the job - just returns the shell command - but sets the job status to 'starting'
+                # so it's important to run this slurm script right away so that the job doesn't get caught in a starting state
+                # forever, for example if the compute resource is restarted
                 cmd = self._job_manager._start_job(job, run_process=False, return_shell_command=True)
                 if cmd:
                     if not using_mock():
+                        # this is how we make sure one and only one job is run in each process
                         f.write(f'if [ "$SLURM_PROCID" == "{ii}" ]; then\n')
                         f.write(f'    {cmd}\n')
+                        f.write(f'    rm slurm_group_assignments/{job.jobId}\n')
                         f.write('fi\n')
                         f.write('\n')
                     else:
                         f.write(f'{cmd}\n')
                         f.write('\n')
                     script_has_at_least_one_job = True
+
+                    # we need to record which slurm group this job went to so we can
+                    # later know how many running groups there are
+                    with open(f'slurm_group_assignments/{job.jobId}', 'w', encoding='utf8') as f2:
+                        f2.write(slurm_group_id)
             f.write('\n')
         if script_has_at_least_one_job:
             # run the slurm script with srun
@@ -72,27 +117,34 @@ class SlurmJobHandler:
             # slurm_time = self._slurm_opts.time
             # slurm_other_opts = self._slurm_opts.otherOpts
 
-            # TODO: figure out where to get this information!
-            slurm_cpus_per_task = 4
-            slurm_partition = 'partition'
-            slurm_time = '1:00:00'
-            slurm_other_opts = ''
+            if num_gpus_per_job > 0:
+                slurm_partition = 'gpu' # hard-coded for flatiron setup - TODO: make this configurable
+            else:
+                slurm_partition = 'ccm' # hard-coded for flatiron setup - TODO: make this configurable
 
-            oo = []
-            if slurm_cpus_per_task is not None:
-                oo.append(f'--cpus-per-task={slurm_cpus_per_task}')
-            if slurm_partition is not None:
-                oo.append(f'--partition={slurm_partition}')
-            if slurm_time is not None:
-                oo.append(f'--time={slurm_time}')
-            if slurm_other_opts is not None:
-                for opt in slurm_other_opts.split(' '):
-                    oo.append(opt)
+            slurm_time = _format_time_for_slurm(timeout_sec_per_job)
+            if slurm_time is None:
+                self._fail_jobs(jobs, f'Invalid timeout_sec_per_job: {timeout_sec_per_job}')
+                return
+
+            oo = [] # the slurm options
+            oo.append(f'-n {len(jobs)}') # number of tasks
+            oo.append(f'--cpus-per-task={num_cpus_per_job}')
+            oo.append(f'--partition={slurm_partition}')
+            if num_gpus_per_job > 0:
+                oo.append(f'---gpus-per-task={num_gpus_per_job}')
+            oo.append(f'--time={slurm_time}')
+
+            # provide memory per cpu
+            mem_per_cpu = int(memory_gb_per_job * 1024 / num_cpus_per_job)
+            oo.append(f'--mem-per-cpu={mem_per_cpu}')
+
             slurm_opts_str = ' '.join(oo)
             if not using_mock():
-                cmd = f'srun -n {len(jobs)} {slurm_opts_str} bash {slurm_script_fname}'
+                cmd = f'srun -n {slurm_opts_str} bash {slurm_script_fname}'
             else:
                 cmd = f'bash {slurm_script_fname}'
+
             print(f'Running slurm batch: {cmd}')
             subprocess.Popen(
                 cmd.split(' '),
@@ -100,3 +152,91 @@ class SlurmJobHandler:
                 stderr=subprocess.DEVNULL,
                 start_new_session=True
             )
+    def _fail_jobs(self, jobs: List[DendroJob], reason: str):
+        for job in jobs:
+            self._job_manager._fail_job(job, reason)
+            self._job_ids_attempted_to_start_or_fail.add(job.jobId)
+    def _determine_num_running_groups(self) -> int:
+        # we need to know how many slurm groups are currently running
+        # so we can limit the number of groups we start at once
+        all_group_ids = []
+        for job in self._jobs:
+            if job.status == 'starting' or job.status == 'running':
+                if os.path.exists(f'slurm_group_assignments/{job.jobId}'):
+                    with open(f'slurm_group_assignments/{job.jobId}', 'r', encoding='utf8') as f:
+                        group_id = f.read().strip()
+                        all_group_ids.append(group_id)
+        return len(set(all_group_ids))
+
+class PendingJobGroup:
+    def __init__(self, jobs: List[DendroJob], required_resources: DendroJobRequiredResources):
+        self._jobs = jobs
+        self._required_resources = required_resources
+
+def _split_jobs_into_groups(jobs: List[DendroJob]) -> List[PendingJobGroup]:
+    jobs = [job for job in jobs if job.requiredResources is not None]
+    ret: List[PendingJobGroup] = []
+    all_batch_ids = set([job.batchId for job in jobs if job.batchId is not None])
+    for batch_id in all_batch_ids:
+        jobs_in_batch = [job for job in jobs if job.batchId == batch_id]
+        assert len(jobs_in_batch) > 0
+        job0 = jobs_in_batch[0]
+        # we assume that all jobs here have the same required resources
+        required_resources = job0.requiredResources
+        assert required_resources is not None
+        if required_resources.numGpus > 0:
+            # every gpu job goes to their own group
+            for job in jobs_in_batch:
+                ret.append(PendingJobGroup([job], required_resources))
+        else:
+            # split into groups based on how many can fit on a single node, determined by numCpus
+            # TODO: take into account memory requirements
+            num_tasks_per_node = num_cpus_per_slurm_node // required_resources.numCpus
+            if num_tasks_per_node == 0:
+                num_tasks_per_node = 1
+            for i in range(0, len(jobs_in_batch), num_tasks_per_node):
+                ret.append(PendingJobGroup(jobs_in_batch[i:i + num_tasks_per_node], required_resources))
+    for job in jobs:
+        if job.batchId is None:
+            assert job.requiredResources is not None
+            ret.append(PendingJobGroup([job], job.requiredResources))
+    return ret
+
+def _format_time_for_slurm(timeout_sec: float):
+    # format is d-hh:mm:ss
+    timeout_sec = int(timeout_sec)
+    if timeout_sec <= 0:
+        return None
+    d = timeout_sec // (24 * 3600)
+    timeout_sec = timeout_sec % (24 * 3600)
+    h = timeout_sec // 3600
+    timeout_sec %= 3600
+    m = timeout_sec // 60
+    timeout_sec %= 60
+    s = timeout_sec
+    if d > 0:
+        return f'{d}-{h:02d}:{m:02d}:{s:02d}'
+    else:
+        return f'{h:02d}:{m:02d}:{s:02d}'
+
+def _create_nice_timestamp():
+    return time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
+
+def _clean_up_old_files():
+    # delete old slurm scripts
+    if os.path.exists('slurm_scripts'):
+        for fname in os.listdir('slurm_scripts'):
+            if fname.startswith('slurm_batch_'):
+                full_fname = os.path.join('slurm_scripts', fname)
+                if os.path.isfile(full_fname):
+                    elapsed_since_modified = time.time() - os.path.getmtime(full_fname)
+                    if elapsed_since_modified > 60 * 60 * 48:
+                        os.remove(full_fname)
+    # delete old slurm group assignments
+    if os.path.exists('slurm_group_assignments'):
+        for fname in os.listdir('slurm_group_assignments'):
+            full_fname = os.path.join('slurm_group_assignments', fname)
+            if os.path.isfile(full_fname):
+                elapsed_since_modified = time.time() - os.path.getmtime(full_fname)
+                if elapsed_since_modified > 60 * 60 * 48:
+                    os.remove(full_fname)

--- a/python/dendro/compute_resource/SlurmJobHandler.py
+++ b/python/dendro/compute_resource/SlurmJobHandler.py
@@ -4,16 +4,15 @@ import time
 import subprocess
 
 from ..mock import using_mock
-from ..common.dendro_types import ComputeResourceSlurmOpts, DendroJob
+from ..common.dendro_types import DendroJob
 
 if TYPE_CHECKING:
     from .JobManager import JobManager
 
 
 class SlurmJobHandler:
-    def __init__(self, *, job_manager: 'JobManager', slurm_opts: ComputeResourceSlurmOpts):
+    def __init__(self, *, job_manager: 'JobManager'):
         self._job_manager = job_manager
-        self._slurm_opts = slurm_opts
         self._jobs: List[DendroJob] = []
         self._job_ids = set()
         self._time_of_last_job_added = 0
@@ -68,10 +67,17 @@ class SlurmJobHandler:
             f.write('\n')
         if script_has_at_least_one_job:
             # run the slurm script with srun
-            slurm_cpus_per_task = self._slurm_opts.cpusPerTask
-            slurm_partition = self._slurm_opts.partition
-            slurm_time = self._slurm_opts.time
-            slurm_other_opts = self._slurm_opts.otherOpts
+            # slurm_cpus_per_task = self._slurm_opts.cpusPerTask
+            # slurm_partition = self._slurm_opts.partition
+            # slurm_time = self._slurm_opts.time
+            # slurm_other_opts = self._slurm_opts.otherOpts
+
+            # TODO: figure out where to get this information!
+            slurm_cpus_per_task = 4
+            slurm_partition = 'partition'
+            slurm_time = '1:00:00'
+            slurm_other_opts = ''
+
             oo = []
             if slurm_cpus_per_task is not None:
                 oo.append(f'--cpus-per-task={slurm_cpus_per_task}')

--- a/python/dendro/compute_resource/SlurmJobHandler.py
+++ b/python/dendro/compute_resource/SlurmJobHandler.py
@@ -141,7 +141,7 @@ class SlurmJobHandler:
 
             slurm_opts_str = ' '.join(oo)
             if not using_mock():
-                cmd = f'srun -n {slurm_opts_str} bash {slurm_script_fname}'
+                cmd = f'srun {slurm_opts_str} bash {slurm_script_fname}'
             else:
                 cmd = f'bash {slurm_script_fname}'
 

--- a/python/dendro/compute_resource/_run_job_in_aws_batch.py
+++ b/python/dendro/compute_resource/_run_job_in_aws_batch.py
@@ -22,21 +22,8 @@ def _run_job_in_aws_batch(
 ):
     import boto3
 
-    aws_access_key_id = os.getenv('BATCH_AWS_ACCESS_KEY_ID', None)
-    if aws_access_key_id is None:
-        raise KeyError('BATCH_AWS_ACCESS_KEY_ID is not set')
-    aws_secret_access_key = os.getenv('BATCH_AWS_SECRET_ACCESS_KEY', None)
-    if aws_secret_access_key is None:
-        raise KeyError('BATCH_AWS_SECRET_ACCESS_KEY is not set')
-    aws_region = os.getenv('BATCH_AWS_REGION', None)
-    if aws_region is None:
-        raise KeyError('BATCH_AWS_REGION is not set')
-
     client = boto3.client(
-        'batch',
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        region_name=aws_region
+        'batch'
     )
 
     stack_id = 'DendroBatchStack'

--- a/python/dendro/compute_resource/_run_job_in_aws_batch.py
+++ b/python/dendro/compute_resource/_run_job_in_aws_batch.py
@@ -1,5 +1,4 @@
 from typing import List
-import os
 
 from ..common.dendro_types import DendroJobRequiredResources
 

--- a/python/dendro/compute_resource/register_compute_resource.py
+++ b/python/dendro/compute_resource/register_compute_resource.py
@@ -9,10 +9,6 @@ env_var_keys = [
     'COMPUTE_RESOURCE_ID',
     'COMPUTE_RESOURCE_PRIVATE_KEY',
     'CONTAINER_METHOD',
-    'SINGLETON_JOB_ID',
-    'BATCH_AWS_ACCESS_KEY_ID',
-    'BATCH_AWS_SECRET_ACCESS_KEY',
-    'BATCH_AWS_REGION',
     'DEFAULT_JOB_RUN_METHOD',
     'AVAILABLE_JOB_RUN_METHODS'
 ]
@@ -55,7 +51,16 @@ def register_compute_resource(*, dir: str, compute_resource_id: Optional[str] = 
         raise ValueError('Cannot specify compute_resource_id or compute_resource_private_key if compute resource node is already initialized.')
 
     with open(env_fname, 'r', encoding='utf8') as f:
-        the_env = yaml.safe_load(f)
+        the_env_from_config_file = yaml.safe_load(f)
+
+    for k in env_var_keys:
+        if k in the_env_from_config_file:
+            the_env[k] = the_env_from_config_file[k]
+        else:
+            the_env_from_config_file[k] = ''
+
+    with open(env_fname, 'w', encoding='utf8') as f:
+        yaml.dump(the_env_from_config_file, f)
 
     COMPUTE_RESOURCE_ID = the_env['COMPUTE_RESOURCE_ID']
     COMPUTE_RESOURCE_PRIVATE_KEY = the_env['COMPUTE_RESOURCE_PRIVATE_KEY']

--- a/python/dendro/compute_resource/register_compute_resource.py
+++ b/python/dendro/compute_resource/register_compute_resource.py
@@ -12,7 +12,9 @@ env_var_keys = [
     'SINGLETON_JOB_ID',
     'BATCH_AWS_ACCESS_KEY_ID',
     'BATCH_AWS_SECRET_ACCESS_KEY',
-    'BATCH_AWS_REGION'
+    'BATCH_AWS_REGION',
+    'DEFAULT_JOB_RUN_METHOD',
+    'AVAILABLE_JOB_RUN_METHODS'
 ]
 
 def register_compute_resource(*, dir: str, compute_resource_id: Optional[str] = None, compute_resource_private_key: Optional[str] = None) -> Tuple[str, str]:

--- a/python/dendro/compute_resource/register_compute_resource.py
+++ b/python/dendro/compute_resource/register_compute_resource.py
@@ -65,6 +65,11 @@ def register_compute_resource(*, dir: str, compute_resource_id: Optional[str] = 
     COMPUTE_RESOURCE_ID = the_env['COMPUTE_RESOURCE_ID']
     COMPUTE_RESOURCE_PRIVATE_KEY = the_env['COMPUTE_RESOURCE_PRIVATE_KEY']
 
+    if not COMPUTE_RESOURCE_ID:
+        raise ValueError('COMPUTE_RESOURCE_ID is not set')
+    if not COMPUTE_RESOURCE_PRIVATE_KEY:
+        raise ValueError('COMPUTE_RESOURCE_PRIVATE_KEY is not set')
+
     timestamp = int(time.time())
     msg = {
         'timestamp': timestamp

--- a/python/dendro/compute_resource/register_compute_resource.py
+++ b/python/dendro/compute_resource/register_compute_resource.py
@@ -87,8 +87,3 @@ def register_compute_resource(*, dir: str, compute_resource_id: Optional[str] = 
     assert COMPUTE_RESOURCE_ID is not None
     assert COMPUTE_RESOURCE_PRIVATE_KEY is not None
     return COMPUTE_RESOURCE_ID, COMPUTE_RESOURCE_PRIVATE_KEY
-
-def _random_string(length: int) -> str:
-    import random
-    import string
-    return ''.join(random.choice(string.ascii_lowercase) for i in range(length))

--- a/python/dendro/compute_resource/start_compute_resource.py
+++ b/python/dendro/compute_resource/start_compute_resource.py
@@ -95,8 +95,8 @@ class Daemon:
                         self._app_manager.update_apps()
 
                 if time_to_handle_jobs or jobs_have_changed:
-                    if time_to_handle_jobs:
-                        print('Checking for new jobs')
+                    # if time_to_handle_jobs:
+                    #     print('Checking for new jobs') # this pollutes the logs too much
                     timer_handle_jobs = time.time()
                     self._handle_jobs()
 

--- a/python/dendro/compute_resource/start_compute_resource.py
+++ b/python/dendro/compute_resource/start_compute_resource.py
@@ -22,9 +22,16 @@ class Daemon:
         if self._compute_resource_private_key is None:
             raise ValueError('Compute resource has not been initialized in this directory, and the environment variable COMPUTE_RESOURCE_PRIVATE_KEY is not set.')
 
+        available_job_run_methods_str = os.getenv('AVAILABLE_JOB_RUN_METHODS', 'local')
+        available_job_run_methods = [s.strip() for s in available_job_run_methods_str.split(',')]
+        for a in available_job_run_methods:
+            if a not in ['local', 'aws_batch', 'slurm']:
+                raise ValueError(f'Invalid job run method: {a}')
+
         self._app_manager = AppManager(
             compute_resource_id=self._compute_resource_id,
-            compute_resource_private_key=self._compute_resource_private_key
+            compute_resource_private_key=self._compute_resource_private_key,
+            available_job_run_methods=available_job_run_methods # type: ignore
         )
         self._app_manager.update_apps()
 

--- a/python/dendro/compute_resource/start_compute_resource.py
+++ b/python/dendro/compute_resource/start_compute_resource.py
@@ -89,7 +89,7 @@ class Daemon:
                 for msg in messages:
                     if msg['type'] == 'newPendingJob':
                         jobs_have_changed = True
-                    if msg['type'] == 'jobStatusChaged':
+                    if msg['type'] == 'jobStatusChanged':
                         jobs_have_changed = True
                     if msg['type'] == 'computeResourceAppsChanaged':
                         self._app_manager.update_apps()

--- a/python/dendro/sdk/App.py
+++ b/python/dendro/sdk/App.py
@@ -7,7 +7,6 @@ from .InputFile import InputFile
 from .AppProcessor import AppProcessor
 from .Job import Job
 from ._run_job import _run_job_parent_process
-from ..common.dendro_types import ComputeResourceSlurmOpts, ComputeResourceAwsBatchOpts
 from ..common._api_request import _processor_get_api_request
 from ._load_spec_from_uri import _load_spec_from_uri
 from .ProcessorBase import ProcessorBase
@@ -49,8 +48,6 @@ class App:
 
         self._spec_dict: Union[dict, None] = None # this is set when the app is loaded from a spec (internal use only)
         self._spec_uri: Union[str, None] = None # this is set when the app is loaded from a spec_uri (internal use only)
-        self._aws_batch_opts: Union[ComputeResourceAwsBatchOpts, None] = None # this is set when the app is loaded from a spec_uri (internal use only)
-        self._slurm_opts: Union[ComputeResourceSlurmOpts, None] = None # this is set when the app is loaded from a spec_uri (internal use only)
 
     def add_processor(self, processor_class: Type[ProcessorBase]):
         """Add a processor to the app
@@ -162,16 +159,12 @@ class App:
 
     @staticmethod
     def from_spec_uri(
-        spec_uri: str,
-        aws_batch_opts: Union[ComputeResourceAwsBatchOpts, None] = None,
-        slurm_opts: Union[ComputeResourceSlurmOpts, None] = None
+        spec_uri: str
     ):
         """Define an app from a spec URI (e.g., a gh url to the spec.json blob). This is called internally."""
         spec: dict = _load_spec_from_uri(spec_uri)
         a = App.from_spec(spec)
         a._spec_uri = spec_uri
-        a._aws_batch_opts = aws_batch_opts
-        a._slurm_opts = slurm_opts
         return a
 
     def _run_job_child_process(self, *, job_id: str, job_private_key: str):

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -19,7 +19,6 @@ async def test_integration(tmp_path):
     from dendro.mock import set_use_mock
     from dendro.api_helpers.clients._get_mongo_client import _clear_mock_mongo_databases
     from dendro.common._api_request import _gui_post_api_request, _client_get_api_request
-    from dendro.common.dendro_types import ComputeResourceSlurmOpts
     from dendro.common.dendro_types import DendroJobRequiredResources
 
     tmpdir = str(tmp_path)
@@ -75,13 +74,7 @@ async def test_integration(tmp_path):
             ),
             DendroComputeResourceApp(
                 name='mock_app_2',
-                specUri=f'file://{tmpdir}/mock_app_2/spec.json',
-                slurm=ComputeResourceSlurmOpts(
-                    partition='test_partition',
-                    time='1:00:00',
-                    cpusPerTask=4,
-                    otherOpts='--test=1'
-                )
+                specUri=f'file://{tmpdir}/mock_app_2/spec.json'
             )
         ]
         _set_compute_resource_apps(
@@ -250,7 +243,8 @@ async def test_integration(tmp_path):
                 processorSpec=processor_spec,
                 batchId=None,
                 dandiApiKey=None,
-                requiredResources=DendroJobRequiredResources(numCpus=1, numGpus=0, memoryGb=8, timeSec=3600)
+                requiredResources=DendroJobRequiredResources(numCpus=1, numGpus=0, memoryGb=8, timeSec=3600),
+                runMethod='local'
             )
             resp = _gui_post_api_request(url_path='/api/gui/jobs', data=_model_dump(req), github_access_token=github_access_token)
             resp = CreateJobResponse(**resp)
@@ -278,7 +272,8 @@ async def test_integration(tmp_path):
             processorSpec=processor_spec_2,
             batchId=None,
             dandiApiKey=None,
-            requiredResources=DendroJobRequiredResources(numCpus=1, numGpus=0, memoryGb=8, timeSec=3600)
+            requiredResources=DendroJobRequiredResources(numCpus=1, numGpus=0, memoryGb=8, timeSec=3600),
+            runMethod='slurm'
         )
         resp = _gui_post_api_request(url_path='/api/gui/jobs', data=_model_dump(req), github_access_token=github_access_token)
         resp = CreateJobResponse(**resp)
@@ -299,7 +294,8 @@ async def test_integration(tmp_path):
             processorSpec=processor_spec_2,
             batchId=None,
             dandiApiKey=None,
-            requiredResources=DendroJobRequiredResources(numCpus=1, numGpus=0, memoryGb=8, timeSec=3600)
+            requiredResources=DendroJobRequiredResources(numCpus=1, numGpus=0, memoryGb=8, timeSec=3600),
+            runMethod='local'
         )
         with pytest.raises(Exception):
             _gui_post_api_request(url_path='/api/gui/jobs', data=_model_dump(req), github_access_token=github_access_token)

--- a/src/dbInterface/dbInterface.ts
+++ b/src/dbInterface/dbInterface.ts
@@ -281,8 +281,8 @@ export type App = {
     specUri?: string
     executablePath?: string // to be removed
     container?: string // to be removed
-    awsBatch?: ComputeResourceAwsBatchOpts
-    slurm?: ComputeResourceSlurmOpts
+    awsBatch?: ComputeResourceAwsBatchOpts // obsolete
+    slurm?: ComputeResourceSlurmOpts // obsolete
 }
 
 export const setComputeResourceApps = async (computeResourceId: string, apps: App[], auth: Auth): Promise<void> => {
@@ -387,11 +387,12 @@ export const createJob = async (
         processorSpec: ComputeResourceSpecProcessor,
         files: DendroFile[],
         batchId?: string,
-        requiredResources: DendroJobRequiredResources
+        requiredResources: DendroJobRequiredResources,
+        runMethod: 'local' | 'aws_batch' | 'slurm'
     },
     auth: Auth
 ) : Promise<string> => {
-    const {projectId, jobDefinition, processorSpec, files, batchId, requiredResources} = a
+    const {projectId, jobDefinition, processorSpec, files, batchId, requiredResources, runMethod} = a
     const processorName = jobDefinition.processorName
     const inputFiles = jobDefinition.inputFiles
     const inputParameters = jobDefinition.inputParameters
@@ -428,7 +429,8 @@ export const createJob = async (
         outputFiles,
         processorSpec,
         batchId,
-        requiredResources
+        requiredResources,
+        runMethod
     }
     if (dandiApiKey) {
         body.dandiApiKey = dandiApiKey

--- a/src/pages/ComputeResourcePage/ComputeResourceAppsTable.tsx
+++ b/src/pages/ComputeResourcePage/ComputeResourceAppsTable.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useCallback, useMemo, useReducer } from "react"
 import { useModalDialog } from "../../ApplicationBar"
 import Hyperlink from "../../components/Hyperlink"
 import ModalWindow from "../../components/ModalWindow/ModalWindow"
-import { ComputeResourceAwsBatchOpts, ComputeResourceSlurmOpts, DendroComputeResource } from "../../types/dendro-types"
+import { DendroComputeResource } from "../../types/dendro-types"
 import { Checkbox, selectedStringsReducer } from "../ProjectPage/FileBrowser/FileBrowser2"
 import ComputeResourceAppsTableMenuBar from "./ComputeResourceAppsTableMenuBar"
 import NewAppWindow from "./NewAppWindow"
@@ -11,8 +11,8 @@ type Props = {
     width: number
     height: number
     computeResource: DendroComputeResource
-    onNewApp: (name: string, specUri: string, absBatch?: ComputeResourceAwsBatchOpts, slurm?: ComputeResourceSlurmOpts) => void
-    onEditApp: (name: string, specUri: string, absBatch?: ComputeResourceAwsBatchOpts, slurm?: ComputeResourceSlurmOpts) => void
+    onNewApp: (name: string, specUri: string) => void
+    onEditApp: (name: string, specUri: string) => void
     onDeleteApps: (appNames: string[]) => void
 }
 
@@ -57,8 +57,6 @@ const ComputeResourceAppsTable: FunctionComponent<Props> = ({width, height, comp
                             <th style={{width: colWidth}} />
                             <th>App</th>
                             <th>Spec URI</th>
-                            <th>AWS Batch</th>
-                            <th>Slurm</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -76,22 +74,6 @@ const ComputeResourceAppsTable: FunctionComponent<Props> = ({width, height, comp
                                     <td>
                                         {app.specUri || ''}
                                     </td>
-                                    <td>
-                                        {app.awsBatch ? `Use AWS Batch: ${app.awsBatch.useAwsBatch ? "true" : "false"}` : ''}
-                                    </td>
-                                    <td>
-                                        {app.slurm ? (
-                                            <span>
-                                                <span>{app.slurm.cpusPerTask ? `CPUs per task: ${app.slurm.cpusPerTask}` : ''}</span>
-                                                &nbsp;
-                                                <span>{app.slurm.partition ? `Partition: ${app.slurm.partition}` : ''}</span>
-                                                &nbsp;
-                                                <span>{app.slurm.time ? `Time: ${app.slurm.time}` : ''}</span>
-                                                &nbsp;
-                                                <span>{app.slurm.otherOpts ? `Other options: ${app.slurm.otherOpts}` : ''}</span>
-                                            </span>
-                                        ) : ''}
-                                    </td>
                                 </tr>
                             ))
                         }
@@ -104,7 +86,7 @@ const ComputeResourceAppsTable: FunctionComponent<Props> = ({width, height, comp
             >
                 <NewAppWindow
                     computeResource={computeResource}
-                    onNewApp={(name, specUri, awsBatch, slurmOpts) => {closeNewAppWindow(); onNewApp(name, specUri, awsBatch, slurmOpts);}}
+                    onNewApp={(name, specUri) => {closeNewAppWindow(); onNewApp(name, specUri);}}
                 />
             </ModalWindow>
             <ModalWindow
@@ -113,7 +95,7 @@ const ComputeResourceAppsTable: FunctionComponent<Props> = ({width, height, comp
             >
                 <NewAppWindow
                     computeResource={computeResource}
-                    onNewApp={(name, specUri, awsBatch, slurmOpts) => {closeEditAppWindow(); onEditApp(name, specUri, awsBatch, slurmOpts);}}
+                    onNewApp={(name, specUri) => {closeEditAppWindow(); onEditApp(name, specUri);}}
                     appBeingEdited={selectedAppForEditing}
                 />
             </ModalWindow>

--- a/src/pages/ComputeResourcePage/ComputeResourcePage.tsx
+++ b/src/pages/ComputeResourcePage/ComputeResourcePage.tsx
@@ -3,7 +3,7 @@ import ComputeResourceNameDisplay from "../../ComputeResourceNameDisplay";
 import { App, fetchComputeResource, fetchJobsForComputeResource, setComputeResourceApps } from "../../dbInterface/dbInterface";
 import { useGithubAuth } from "../../GithubAuth/useGithubAuth";
 import { timeAgoString } from "../../timeStrings";
-import { ComputeResourceAwsBatchOpts, ComputeResourceSlurmOpts, DendroComputeResource, DendroJob } from "../../types/dendro-types";
+import { DendroComputeResource, DendroJob } from "../../types/dendro-types";
 import UserIdComponent from "../../UserIdComponent";
 import JobsTable from "../ProjectPage/JobsWindow/JobsTable";
 import ComputeResourceAppsTable from "./ComputeResourceAppsTable";
@@ -51,10 +51,10 @@ const ComputeResourcesPage: FunctionComponent<Props> = ({width, height, computeR
             }) : undefined
     }, [jobs])
 
-    const handleNewApp = useCallback((name: string, specUri: string, awsBatch?: ComputeResourceAwsBatchOpts, slurm?: ComputeResourceSlurmOpts) => {
+    const handleNewApp = useCallback((name: string, specUri: string) => {
         if (!computeResource) return
         const oldApps = computeResource.apps
-        const newApps: App[] = [...oldApps.filter(a => (a.name !== name)), {name, specUri, awsBatch, slurm}]
+        const newApps: App[] = [...oldApps.filter(a => (a.name !== name)), {name, specUri}]
         setComputeResourceApps(computeResource.computeResourceId, newApps, auth).then(() => {
             refreshComputeResource()
         })

--- a/src/pages/ComputeResourcePage/NewAppWindow.tsx
+++ b/src/pages/ComputeResourcePage/NewAppWindow.tsx
@@ -1,33 +1,21 @@
 import { FunctionComponent, useEffect, useMemo, useState } from "react"
 import { App } from "../../dbInterface/dbInterface"
-import { ComputeResourceAwsBatchOpts, ComputeResourceSlurmOpts, DendroComputeResource } from "../../types/dendro-types"
+import { DendroComputeResource } from "../../types/dendro-types"
 
 type Props = {
     computeResource: DendroComputeResource
-    onNewApp: (name: string, specUri: string, awsBatch?: ComputeResourceAwsBatchOpts, slurm?: ComputeResourceSlurmOpts) => void
+    onNewApp: (name: string, specUri: string) => void
     appBeingEdited?: App
 }
 
 const NewAppWindow: FunctionComponent<Props> = ({computeResource, onNewApp, appBeingEdited}) => {
     const [newAppName, setNewAppName] = useState('')
     const [newSpecUri, setNewSpecUri] = useState('')
-    const [newAwsBatchOpts, setNewAwsBatchOpts] = useState<ComputeResourceAwsBatchOpts | undefined>(undefined)
-    const [newSlurmOpts, setNewSlurmOpts] = useState<ComputeResourceSlurmOpts | undefined>(undefined)
-
-    const [newAwsBatchOptsValid, setNewAwsBatchOptsValid] = useState(false)
-    const [newSlurmOptsValid, setNewSlurmOptsValid] = useState(false)
 
     useEffect(() => {
         if (!appBeingEdited) return
         setNewAppName(appBeingEdited.name)
         setNewSpecUri(appBeingEdited.specUri || '')
-        if ((appBeingEdited.awsBatch) && (appBeingEdited.awsBatch.useAwsBatch)) {
-            setNewAwsBatchOpts(appBeingEdited.awsBatch)
-        }
-        else {
-            setNewAwsBatchOpts(undefined)
-        }
-        setNewSlurmOpts(appBeingEdited.slurm)
     }, [appBeingEdited])
     
     const isValidAppName = useMemo(() => ((appName: string) => {
@@ -41,11 +29,8 @@ const NewAppWindow: FunctionComponent<Props> = ({computeResource, onNewApp, appB
     const isValid = useMemo(() => {
         if (!isValidAppName(newAppName)) return false
         if (!isValidSpecUri(newSpecUri)) return false
-        if (!newAwsBatchOptsValid) return false
-        if (!newSlurmOptsValid) return false
-        if (newAwsBatchOpts && newSlurmOpts) return false
         return true
-    }, [newAppName, newSpecUri, newAwsBatchOpts, newSlurmOpts, isValidAppName, newAwsBatchOptsValid, newSlurmOptsValid])
+    }, [newAppName, newSpecUri, isValidAppName])
 
     return (
         <div style={{fontSize: 11}}>
@@ -93,26 +78,12 @@ const NewAppWindow: FunctionComponent<Props> = ({computeResource, onNewApp, appB
                         <tr>
                             <td>Spec URI</td>
                             <td>
-                                <input type="text" id="new-spec-uri" value={newSpecUri} onChange={e => setNewSpecUri(e.target.value)} />                
+                                <input style={{width: 600}} type="text" id="new-spec-uri" value={newSpecUri} onChange={e => setNewSpecUri(e.target.value)} />                
                             </td>
                         </tr>
                     </tbody>
                 </table>
             </div>
-            <br />
-            <hr />
-            <EditAwsBatchOpts
-                value={newAwsBatchOpts}
-                onChange={setNewAwsBatchOpts}
-                setValid={setNewAwsBatchOptsValid}
-            />
-            <br />
-            <hr />
-            <EditSlurmOpts
-                value={newSlurmOpts}
-                onChange={setNewSlurmOpts}
-                setValid={setNewSlurmOptsValid}
-            />
             <br />
             <hr />
             {/* Indicator on whether the app is valid */}
@@ -135,7 +106,7 @@ const NewAppWindow: FunctionComponent<Props> = ({computeResource, onNewApp, appB
             </p>
             <div>&nbsp;</div>
             {/* Button to create the app */}
-            <button disabled={!isValid} onClick={() => onNewApp(newAppName, newSpecUri, newAwsBatchOpts, newSlurmOpts)}>
+            <button disabled={!isValid} onClick={() => onNewApp(newAppName, newSpecUri)}>
                 {
                     !appBeingEdited ? (
                         <span>Add new app</span>
@@ -153,159 +124,6 @@ const isValidSpecUri = (specUri: string) => {
     if (specUri.startsWith('file://')) return true
     if (specUri.startsWith('http')) return true
     return false
-}
-
-type EditAwsBatchOptsProps = {
-    value: ComputeResourceAwsBatchOpts | undefined
-    onChange: (value: ComputeResourceAwsBatchOpts | undefined) => void
-    setValid: (valid: boolean) => void
-}
-
-const EditAwsBatchOpts: FunctionComponent<EditAwsBatchOptsProps> = ({value, onChange, setValid}) => {
-    const [internalUseAwsBatch, setInternalUseAwsBatch] = useState(false)
-
-    useEffect(() => {
-        if (!value) {
-            setInternalUseAwsBatch(false)
-            return
-        }
-        setInternalUseAwsBatch(!!value.useAwsBatch)
-    }, [value])
-
-    useEffect(() => {
-        // if (!internalJobQueue && !internalJobDefinition) {
-        //     onChange(undefined)
-        //     setValid(true)
-        //     return
-        // }
-        // if (!internalJobQueue || !internalJobDefinition) {
-        //     setValid(false)
-        //     return
-        // }
-        // onChange({
-        //     jobQueue: internalJobQueue,
-        //     jobDefinition: internalJobDefinition
-        // })
-        onChange({
-            useAwsBatch: internalUseAwsBatch
-        })
-        setValid(true)
-    }, [setValid, onChange, internalUseAwsBatch])
-
-    return (
-        <div>
-            <h4>AWS Batch</h4>
-            <div>
-                <table>
-                    <tbody>
-                        {/* <tr>
-                            <td>Job queue</td>
-                            <td>
-                                <input type="text" id="new-aws-batch-job-queue" value={internalJobQueue} onChange={e => setInternalJobQueue(e.target.value)} />                
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Job definition</td>
-                            <td>
-                                <input type="text" id="new-aws-batch-job-definition" value={internalJobDefinition} onChange={e => setInternalJobDefinition(e.target.value)} />
-                            </td>
-                        </tr> */}
-                        <tr>
-                            <td>Use AWS Batch</td>
-                            <td>
-                                <input type="checkbox" id="new-aws-batch-use-aws-batch" checked={internalUseAwsBatch} onChange={e => setInternalUseAwsBatch(e.target.checked)} />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    )
-}
-
-type EditSlurmOptsProps = {
-    value: ComputeResourceSlurmOpts | undefined
-    onChange: (value: ComputeResourceSlurmOpts | undefined) => void
-    setValid: (valid: boolean) => void
-}
-
-const EditSlurmOpts: FunctionComponent<EditSlurmOptsProps> = ({value, onChange, setValid}) => {
-    const [internalCpusPerTask, setInternalCpusPerTask] = useState('')
-    const [internalPartition, setInternalPartition] = useState('')
-    const [internalTime, setInternalTime] = useState('')
-    const [internalOtherOpts, setInternalOtherOpts] = useState('')
-
-    useEffect(() => {
-        if (!value) {
-            setInternalCpusPerTask('')
-            setInternalPartition('')
-            setInternalTime('')
-            setInternalOtherOpts('')
-            return
-        }
-        setInternalCpusPerTask(value.cpusPerTask !== undefined ? value.cpusPerTask + '' : '')
-        setInternalPartition(value.partition || '')
-        setInternalTime(value.time || '')
-        setInternalOtherOpts(value.otherOpts || '')
-    }, [value])
-
-    useEffect(() => {
-        if (!internalCpusPerTask && !internalPartition && !internalTime && !internalOtherOpts) {
-            onChange(undefined)
-            setValid(true)
-            return
-        }
-        if ((internalCpusPerTask) && (!isValidInteger(internalCpusPerTask))) {
-            setValid(false)
-            return
-        }
-        onChange({
-            cpusPerTask: internalCpusPerTask ? parseInt(internalCpusPerTask) : undefined,
-            partition: internalPartition || undefined,
-            time: internalTime || undefined,
-            otherOpts: internalOtherOpts || undefined
-        })
-        setValid(true)
-    }, [internalCpusPerTask, internalPartition, internalTime, internalOtherOpts, onChange, setValid])
-
-    return (
-        <div>
-            <h4>Slurm</h4>
-            <table>
-                <tbody>
-                    <tr>
-                        <td>CPUs per task</td>
-                        <td>
-                            <input type="text" id="new-slurm-cpus-per-task" value={internalCpusPerTask} onChange={e => setInternalCpusPerTask(e.target.value)} />
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Partition</td>
-                        <td>
-                            <input type="text" id="new-slurm-partition" value={internalPartition} onChange={e => setInternalPartition(e.target.value)} />
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Time</td>
-                        <td>
-                            <input type="text" id="new-slurm-time" value={internalTime} onChange={e => setInternalTime(e.target.value)} />
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Other options</td>
-                        <td>
-                            <input type="text" id="new-slurm-other-opts" value={internalOtherOpts} onChange={e => setInternalOtherOpts(e.target.value)} />
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    )
-}
-
-const isValidInteger = (value: string) => {
-    const regex = /^\d+$/
-    return value.match(regex)
 }
 
 export default NewAppWindow

--- a/src/pages/ProjectPage/ComputeResourceAppsTable2/ComputeResourceAppsTable2.tsx
+++ b/src/pages/ProjectPage/ComputeResourceAppsTable2/ComputeResourceAppsTable2.tsx
@@ -1,13 +1,13 @@
 import { FunctionComponent, useCallback, useEffect, useMemo, useReducer, useState } from "react"
-import { Checkbox, selectedStringsReducer } from "../FileBrowser/FileBrowser2"
 import { useModalDialog } from "../../../ApplicationBar"
-import { ComputeResourceAwsBatchOpts, ComputeResourceSlurmOpts, DendroComputeResource } from "../../../types/dendro-types"
-import { App, fetchComputeResource, setComputeResourceApps } from "../../../dbInterface/dbInterface"
 import { useGithubAuth } from "../../../GithubAuth/useGithubAuth"
-import ComputeResourceAppsTableMenuBar2 from "./ComputeResourceAppsTableMenuBar2"
 import Hyperlink from "../../../components/Hyperlink"
 import ModalWindow from "../../../components/ModalWindow/ModalWindow"
+import { App, fetchComputeResource, setComputeResourceApps } from "../../../dbInterface/dbInterface"
+import { DendroComputeResource } from "../../../types/dendro-types"
 import NewAppWindow from "../../ComputeResourcePage/NewAppWindow"
+import { Checkbox, selectedStringsReducer } from "../FileBrowser/FileBrowser2"
+import ComputeResourceAppsTableMenuBar2 from "./ComputeResourceAppsTableMenuBar2"
 
 type Props = {
     computeResourceId: string
@@ -47,10 +47,10 @@ const ComputeResourceAppsTable2: FunctionComponent<Props> = ({computeResourceId}
         // TODO
     }, [])
 
-    const handleNewApp = useCallback((name: string, specUri: string, awsBatch?: ComputeResourceAwsBatchOpts, slurm?: ComputeResourceSlurmOpts) => {
+    const handleNewApp = useCallback((name: string, specUri: string) => {
         if (!computeResource) return
         const oldApps = computeResource.apps
-        const newApps: App[] = [...oldApps.filter(a => (a.name !== name)), {name, specUri, awsBatch, slurm}]
+        const newApps: App[] = [...oldApps.filter(a => (a.name !== name)), {name, specUri}]
         setComputeResourceApps(computeResource.computeResourceId, newApps, auth).then(() => {
             refreshComputeResource()
         })
@@ -95,8 +95,6 @@ const ComputeResourceAppsTable2: FunctionComponent<Props> = ({computeResourceId}
                             <th style={{width: colWidth}} />
                             <th>App</th>
                             <th>Spec URI</th>
-                            <th>AWS Batch</th>
-                            <th>Slurm</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -114,22 +112,6 @@ const ComputeResourceAppsTable2: FunctionComponent<Props> = ({computeResourceId}
                                     <td>
                                         {app.specUri || ''}
                                     </td>
-                                    <td>
-                                        {app.awsBatch ? `Using AWS Batch: ${app.awsBatch.useAwsBatch ? "true" : "false"}` : ''}
-                                    </td>
-                                    <td>
-                                        {app.slurm ? (
-                                            <span>
-                                                <span>{app.slurm.cpusPerTask ? `CPUs per task: ${app.slurm.cpusPerTask}` : ''}</span>
-                                                &nbsp;
-                                                <span>{app.slurm.partition ? `Partition: ${app.slurm.partition}` : ''}</span>
-                                                &nbsp;
-                                                <span>{app.slurm.time ? `Time: ${app.slurm.time}` : ''}</span>
-                                                &nbsp;
-                                                <span>{app.slurm.otherOpts ? `Other options: ${app.slurm.otherOpts}` : ''}</span>
-                                            </span>
-                                        ) : ''}
-                                    </td>
                                 </tr>
                             ))
                         }
@@ -142,7 +124,7 @@ const ComputeResourceAppsTable2: FunctionComponent<Props> = ({computeResourceId}
             >
                 {computeResource && <NewAppWindow
                     computeResource={computeResource}
-                    onNewApp={(name, specUri, awsBatch, slurmOpts) => {closeNewAppWindow(); handleNewApp(name, specUri, awsBatch, slurmOpts);}}
+                    onNewApp={(name, specUri) => {closeNewAppWindow(); handleNewApp(name, specUri);}}
                 />}
             </ModalWindow>
             <ModalWindow
@@ -151,7 +133,7 @@ const ComputeResourceAppsTable2: FunctionComponent<Props> = ({computeResourceId}
             >
                 {computeResource && <NewAppWindow
                     computeResource={computeResource}
-                    onNewApp={(name, specUri, awsBatch, slurmOpts) => {closeEditAppWindow(); handleNewApp(name, specUri, awsBatch, slurmOpts);}}
+                    onNewApp={(name, specUri) => {closeEditAppWindow(); handleNewApp(name, specUri);}}
                     appBeingEdited={selectedAppForEditing}
                 />}
             </ModalWindow>

--- a/src/pages/ProjectPage/DandiUpload/DandiUploadWindow.tsx
+++ b/src/pages/ProjectPage/DandiUpload/DandiUploadWindow.tsx
@@ -84,18 +84,23 @@ const DandiUploadWindow: FunctionComponent<DandiUploadWindowProps> = ({ dandiUpl
             memoryGb: 8,
             timeSec: 3600 * 1
         }
+        const defaultRunMethod = computeResource?.spec?.defaultJobRunMethod
+        if (!defaultRunMethod) {
+            throw new Error(`defaultRunMethod not found for compute resource: ${computeResource?.computeResourceId}`)
+        }
         const job = {
             projectId,
             jobDefinition: jobDef,
             processorSpec: processor,
             files,
             batchId: undefined,
-            requiredResources
+            requiredResources,
+            runMethod: defaultRunMethod
         }
         console.log('CREATING JOB', job)
         await createJob(job, auth)
         onClose()
-    }, [processor, dandiUploadTask, projectId, files, auth, dandiApiKey, onClose, jobs])
+    }, [processor, dandiUploadTask, projectId, files, auth, dandiApiKey, onClose, jobs, computeResource])
 
     if (!['admin', 'editor'].includes(projectRole || '')) {
         return (

--- a/src/pages/ProjectPage/FileEditor/SpikeSortingOutputSection/SpikeSortingOutputSection.tsx
+++ b/src/pages/ProjectPage/FileEditor/SpikeSortingOutputSection/SpikeSortingOutputSection.tsx
@@ -112,15 +112,20 @@ const SpikeSortingOutputSection: FunctionComponent<SpikeSortingOutputSectionProp
             memoryGb: 8,
             timeSec: 3600
         }
+        const defaultRunMethod = computeResource?.spec?.defaultJobRunMethod
+        if (!defaultRunMethod) {
+            throw new Error(`defaultJobRunMethod not found for compute resource: ${computeResource?.computeResourceId}`)
+        }
         await createJob({
             projectId,
             jobDefinition,
             processorSpec: spikeSortingFigurlProcessor,
             files,
             batchId: undefined,
-            requiredResources
+            requiredResources,
+            runMethod: defaultRunMethod
         }, auth)
-    }, [spikeSortingFigurlProcessor, projectId, recordingFileName, auth, fileName, electricalSeriesPath, files])
+    }, [spikeSortingFigurlProcessor, projectId, recordingFileName, auth, fileName, electricalSeriesPath, files, computeResource])
 
     const handleOpenSpikeSortingView = useCallback(async () => {
         if (!spikeSortingFigurlFile) return

--- a/src/pages/ProjectPage/RunBatchSpikeSortingWindow/RunBatchSpikeSortingWindow.tsx
+++ b/src/pages/ProjectPage/RunBatchSpikeSortingWindow/RunBatchSpikeSortingWindow.tsx
@@ -351,13 +351,10 @@ const LeftColumn: FunctionComponent<LeftColumnProps> = ({
             {requiredResources && <RequiredResourcesEditor
                 requiredResources={requiredResources}
                 setRequiredResources={setRequiredResources}
-            />}
-            <div>&nbsp;</div><hr /><div>&nbsp;</div>
-            <RunMethodSelector
                 runMethod={runMethod}
                 setRunMethod={setRunMethod}
                 availableRunMethods={availableRunMethods}
-            />
+            />}
             <div>&nbsp;</div><hr /><div>&nbsp;</div>
             <div>
                 {/* Large submit button */}
@@ -495,6 +492,9 @@ export const formDescriptionStringFromProcessorName = (processorName: string) =>
 }
 
 type RequiredResourcesEditorProps = {
+    runMethod: 'local' | 'aws_batch' | 'slurm'
+    setRunMethod: (method: 'local' | 'aws_batch' | 'slurm') => void
+    availableRunMethods: ('local' | 'aws_batch' | 'slurm')[]
     requiredResources: DendroJobRequiredResources
     setRequiredResources: (val: DendroJobRequiredResources) => void
 }
@@ -503,14 +503,26 @@ const numGpusChoices = [0, 1]
 const memoryGbChoices = [2, 4, 8, 16, 32]
 const timeMinChoices = [1, 5, 10, 30, 60, 120, 180, 240, 300, 360, 420, 480, 540, 600, 660, 720, 1440, 1440 * 2, 1440 * 3, 1440 * 4, 1440 * 5, 1440 * 6, 1440 * 7]
 
-const RequiredResourcesEditor: FunctionComponent<RequiredResourcesEditorProps> = ({requiredResources, setRequiredResources}) => {
+const RequiredResourcesEditor: FunctionComponent<RequiredResourcesEditorProps> = ({requiredResources, setRequiredResources, runMethod, setRunMethod, availableRunMethods}) => {
     const {numCpus, numGpus, memoryGb, timeSec} = requiredResources
     const WW = 70
     return (
         <div>
-            <h3>Resource requirements</h3>
+            <h3>Resources</h3>
             <table className="table1" style={{maxWidth: 500}}>
                 <tbody>
+                    <tr>
+                        <td>Run method</td>
+                        <td>
+                            <select value={runMethod} onChange={evt => setRunMethod(evt.target.value as any)}>
+                                {
+                                    availableRunMethods.map(method => (
+                                        <option key={method} value={method}>{method}</option>
+                                    ))
+                                }
+                            </select>
+                        </td>
+                    </tr>
                     <tr>
                         <td>Number of CPUs</td>
                         <td>

--- a/src/pages/ProjectPage/RunBatchSpikeSortingWindow/RunMethodSelector.tsx
+++ b/src/pages/ProjectPage/RunBatchSpikeSortingWindow/RunMethodSelector.tsx
@@ -1,0 +1,23 @@
+import { FunctionComponent } from "react"
+
+type RunMethodSelectorProps = {
+    runMethod: 'local' | 'aws_batch' | 'slurm'
+    setRunMethod: (method: 'local' | 'aws_batch' | 'slurm') => void
+    availableRunMethods: ('local' | 'aws_batch' | 'slurm')[]
+}
+
+const RunMethodSelector: FunctionComponent<RunMethodSelectorProps> = ({ runMethod, setRunMethod, availableRunMethods }) => {
+    return (
+        <div>
+            <select value={runMethod} onChange={e => setRunMethod(e.target.value as any)}>
+                {
+                    availableRunMethods.map(method => (
+                        <option key={method} value={method}>{method}</option>
+                    ))
+                }
+            </select>
+        </div>
+    )
+}
+
+export default RunMethodSelector

--- a/src/types/dendro-types.ts
+++ b/src/types/dendro-types.ts
@@ -372,16 +372,16 @@ export const isComputeResourceSpecApp = (x: any): x is ComputeResourceSpecApp =>
 }
 
 export type ComputeResourceSpec = {
+    apps: ComputeResourceSpecApp[]
     defaultJobRunMethod?: 'local' | 'aws_batch' | 'slurm'
     availableJobRunMethods?: ('local' | 'aws_batch' | 'slurm')[]
-    apps: ComputeResourceSpecApp[]
 }
 
 export const isComputeResourceSpec = (x: any): x is ComputeResourceSpec => {
     return validateObject(x, {
+        apps: isArrayOf(isComputeResourceSpecApp),
         defaultJobRunMethod: optional(isOneOf([isEqualTo('local'), isEqualTo('aws_batch'), isEqualTo('slurm')])),
         availableJobRunMethods: optional(isArrayOf(isOneOf([isEqualTo('local'), isEqualTo('aws_batch'), isEqualTo('slurm')]))),
-        apps: isArrayOf(isComputeResourceSpecApp)
     })
 }
 

--- a/src/types/dendro-types.ts
+++ b/src/types/dendro-types.ts
@@ -217,6 +217,7 @@ export type DendroJob = {
     outputFiles: DendroJobOutputFile[]
     requiredResources?: DendroJobRequiredResources
     usedResources?: DendroJobUsedResources
+    runMethod?: 'local' | 'aws_batch' | 'slurm'
     timestampCreated: number
     computeResourceId: string
     status: 'pending' | 'queued' | 'starting' | 'running' | 'completed' | 'failed'
@@ -250,6 +251,7 @@ export const isDendroJob = (x: any): x is DendroJob => {
         outputFiles: isArrayOf(isDendroJobOutputFile),
         requiredResources: optional(isDendroJobRequiredResources),
         usedResources: optional(isDendroJobUsedResources),
+        runMethod: optional(isOneOf([isEqualTo('local'), isEqualTo('aws_batch'), isEqualTo('slurm')])),
         timestampCreated: isNumber,
         computeResourceId: isString,
         status: isOneOf([isEqualTo('pending'), isEqualTo('queued'), isEqualTo('starting'), isEqualTo('running'), isEqualTo('completed'), isEqualTo('failed')]),

--- a/src/types/dendro-types.ts
+++ b/src/types/dendro-types.ts
@@ -296,12 +296,14 @@ export const isDendroFile = (x: any): x is DendroFile => {
     })
 }
 
+// obsolete
 export type ComputeResourceAwsBatchOpts = {
     jobQueue?: string // obsolete
     jobDefinition?: string
     useAwsBatch?: boolean
 }
 
+// obsolete
 export const isComputeResourceAwsBatchOpts = (x: any): x is ComputeResourceAwsBatchOpts => {
     return validateObject(x, {
         jobQueue: optional(isString), // obsolete
@@ -311,6 +313,7 @@ export const isComputeResourceAwsBatchOpts = (x: any): x is ComputeResourceAwsBa
 }
 
 
+// obsolete
 export type ComputeResourceSlurmOpts = {
     partition?: string
     time?: string
@@ -318,6 +321,7 @@ export type ComputeResourceSlurmOpts = {
     otherOpts?: string
 }
 
+// obsolete
 export const isComputeResourceSlurmOpts = (x: any): x is ComputeResourceSlurmOpts => {
     return validateObject(x, {
         partition: optional(isString),
@@ -332,8 +336,8 @@ export type DendroComputeResourceApp = {
     specUri?: string
     executablePath?: string // to be removed
     container?: string // to be removed
-    awsBatch?: ComputeResourceAwsBatchOpts
-    slurm?: ComputeResourceSlurmOpts
+    awsBatch?: ComputeResourceAwsBatchOpts // obsolete
+    slurm?: ComputeResourceSlurmOpts // obsolete
 }
 
 export const isDendroComputeResourceApp = (x: any): x is DendroComputeResourceApp => {
@@ -342,8 +346,8 @@ export const isDendroComputeResourceApp = (x: any): x is DendroComputeResourceAp
         specUri: optional(isString),
         executablePath: optional(isString), // to be removed
         container: optional(isString), // to be removed
-        awsBatch: optional(isComputeResourceAwsBatchOpts),
-        slurm: optional(isComputeResourceSlurmOpts)
+        awsBatch: optional(isComputeResourceAwsBatchOpts), // obsolete
+        slurm: optional(isComputeResourceSlurmOpts) // obsolete
     })
 }
 
@@ -366,11 +370,15 @@ export const isComputeResourceSpecApp = (x: any): x is ComputeResourceSpecApp =>
 }
 
 export type ComputeResourceSpec = {
+    defaultJobRunMethod?: 'local' | 'aws_batch' | 'slurm'
+    availableJobRunMethods?: ('local' | 'aws_batch' | 'slurm')[]
     apps: ComputeResourceSpecApp[]
 }
 
 export const isComputeResourceSpec = (x: any): x is ComputeResourceSpec => {
     return validateObject(x, {
+        defaultJobRunMethod: optional(isOneOf([isEqualTo('local'), isEqualTo('aws_batch'), isEqualTo('slurm')])),
+        availableJobRunMethods: optional(isArrayOf(isOneOf([isEqualTo('local'), isEqualTo('aws_batch'), isEqualTo('slurm')]))),
         apps: isArrayOf(isComputeResourceSpecApp)
     })
 }


### PR DESCRIPTION
As discussed/planned, the run method (local, aws_batch, slurm) should not be associated with the installed app, but should be specified at job submission.

Compute resources now have two new config variables

DEFAULT_JOB_RUN_METHOD: could be "local", "aws_batch", or "slurm"

AVAILABLE_JOB_RUN_METHODS: comma-separated list of strings, with each string being "local", "aws_batch", or "slurm"

On job submission window, there is now a selector for choosing the run method among those available for the compute resource.