### PR TITLE
include g4dn xlarge option

### DIFF
--- a/iac/aws_batch/aws_batch/aws_batch_stack.py
+++ b/iac/aws_batch/aws_batch/aws_batch_stack.py
@@ -198,6 +198,7 @@ class AwsBatchStack(Stack):
             id=compute_env_gpu_id,
             vpc=vpc,
             instance_types=[
+                ec2.InstanceType("g4dn.xlarge"), # 4 vCPUs, 16 GiB
                 ec2.InstanceType("g4dn.2xlarge"), # 8 vCPUs, 32 GiB
                 # ec2.InstanceType("g4dn.4xlarge"), # 16 vCPUs, 64 GiB
             ],


### PR DESCRIPTION
Cheaper machine that might perform just the same as the g4dn.2xlarge. If we have both set as options to the compute environment, the chosen number of vcpus / memory in the GUI should be enough for AWS Batch to allocate the job in the right instance type