### PR TITLE
custom events for utilization log

### DIFF
--- a/python/dendro/sdk/_resource_utilization_log_reader.py
+++ b/python/dendro/sdk/_resource_utilization_log_reader.py
@@ -22,6 +22,7 @@ def _resource_utilization_log_reader(outq: queue.Queue, exit_event: threading.Ev
         net_io_counters = psutil.net_io_counters(pernic=False, nowrap=True)
         gpu_loads = _get_gpu_loads()
         log_record = {
+            'type': 'utilization_event',
             'timestamp': time.time(),
             'cpu': {
                 'percent': cpu_percent


### PR DESCRIPTION
@luiztauffer This hasn't been tested at all, but could you take a look.

Addresses #86 

Looking for events of the form `##dendro-event##{...}\n` in the console output of the job. These get included in the resource utilization log.